### PR TITLE
Fetch calendar from SVN

### DIFF
--- a/get_calendar.sh
+++ b/get_calendar.sh
@@ -1,0 +1,3 @@
+echo "Fetching calendar from SVN"
+cd content/foundation/board || exit
+/usr/bin/svn export https://svn.apache.org/repos/asf/infrastructure/site/trunk/content/foundation/board/calendar.md --force

--- a/pelicanconf.yaml
+++ b/pelicanconf.yaml
@@ -16,6 +16,8 @@ plugins:
 
 setup:
   data: asfdata.yaml
+  run:
+    - /bin/bash get_calendar.sh
   ignore:
     - README.md
     - interviews


### PR DESCRIPTION
Add script to fetch calendar.md from SVN

Once this is working, calendar.md can be dropped from Git (and ignored?)