### PR TITLE
Add new member Weiwei Yang

### DIFF
--- a/content/foundation/members.md
+++ b/content/foundation/members.md
@@ -573,6 +573,7 @@ N.B. the listing below is optional; there is a separate summary of  [members](ht
 | wave | Dave Fisher | [POI](https://poi.apache.org/), [Incubator](https://incubator.apache.org/), [OpenOffice](https://openoffice.apache.org/), [Petri](https://petri.apache.org/), and others |
 | weber | Volker Weber | [MyFaces](http://myfaces.apache.org/)|
 | weimer | [Markus Weimer](http://www.markusweimer.com) |
+| wwei | [Weiwei Yang](https://yangwwei.github.io) | [Hadoop](https://hadoop.apache.org), [Ozone](https://ozone.apache.org), [YuniKorn](https://yunikorn.apache.org) |
 | wglass | William Glass-Husain |
 | wohali | [Joan Touzet](mailto:wohali@apache.org) | [CouchDB](http://couchdb.apache.org) |
 | woollard | David Matthew Woollard |


### PR DESCRIPTION
Update https://www.apache.org/foundation/members.html, adding new member Weiwei Yang.
Weiwei has already been listed here: http://home.apache.org/committers-by-project.html#member.