### PR TITLE
Set canonical URL to 'www.apache.org'

### DIFF
--- a/theme/apache/templates/base.html
+++ b/theme/apache/templates/base.html
@@ -21,6 +21,7 @@
   <link rel="icon" type="image/png" href="/favicons/favicon-16x16.png" sizes="16x16">
   <link rel="manifest" href="/favicons/manifest.json">
   <link rel="shortcut icon" href="/favicons/favicon.ico">
+  <link rel="canonical" href="{{ ("https://www.apache.org/" + page.url) | replace ("/index.html","") }}">
   <meta name="msapplication-TileColor" content="#603cba">
   <meta name="msapplication-TileImage" content="/favicons/mstile-144x144.png">
   <meta name="msapplication-config" content="/favicons/browserconfig.xml">


### PR DESCRIPTION
Even though the site is also deployed at 'apache.org'.

Fixes https://github.com/apache/www-site/issues/178

Needs https://github.com/apache/infrastructure-pelican/pull/47 to be merged first.