### PR TITLE
Use https endpoint for struts.apache.org and developer references

### DIFF
--- a/content/foundation/members.md
+++ b/content/foundation/members.md
@@ -245,7 +245,7 @@ There is a complete summary of the [member LDAP group](http://home.apache.org/co
 | joehni | Jörg Schaible |
 | joern | Jörn Kottmann | [UIMA](http://uima.apache.org/) ; [OpenNLP](http://opennlp.apache.org/)|
 | joewitt | Joe Witt | [NiFi](https://nifi.apache.org/)|
-| jogep | [Johannes Geppert](http://www.jgeppert.com) | [Struts](http://struts.apache.org/) |
+| jogep | [Johannes Geppert](https://www.jgeppert.com) | [Struts](https://struts.apache.org/) |
 | jon | [Jon Scott Stevens](http://www.whichever.com/) | [Ant](http://ant.apache.org/) ; [ECS](http://jakarta.apache.org/ecs/) ; [ORO](http://jakarta.apache.org/oro/) ; [Regexp](http://jakarta.apache.org/regexp/) ; [Tomcat](http://jakarta.apache.org/tomcat/) ; [Velocity](http://jakarta.apache.org/velocity/) ; [James](http://james.apache.org/) ; [Jetspeed](http://jakarta.apache.org/jetspeed/) ; [JServ](http://java.apache.org/jserv/) ; [Jyve](http://java.apache.org/jyve/) ; [Turbine](http://java.apache.org/turbine/)|
 | jonesde | David E. Jones |
 | jorton | Joe Orton | [APR](http://apr.apache.org/) ; [httpd](http://httpd.apache.org/)|
@@ -331,7 +331,7 @@ There is a complete summary of the [member LDAP group](http://home.apache.org/co
 | ndbeyer | Nathan Beyer |
 | neilg | Neil Graham |
 | ngn | [Niklas Gustavsson](http://protocol7.com) | [MINA](http://mina.apache.org)|
-| niallp | Niall Pemberton | [Jakarta](http://jakarta.apache.org/) ; [Struts](http://struts.apache.org/)|
+| niallp | Niall Pemberton | [Jakarta](http://jakarta.apache.org/) ; [Struts](https://struts.apache.org/)|
 | nick | Nick Burch |
 | niclas | Niclas Hedhman |
 | ningjiang | Willem Ning Jiang |[activemq](http://activemq.apache.org/);[camel](http://camel.apache.org);[cxf](http://cxf.apache.org); [doris](http://doris.apache.org); [iotdb](http://iotdb.apache.org); [rocketmq](http://rocketmq.apache.org); [servicecomb](http://servicecomb.apache.org); [servicemix](http://servicemix.apache.org); [shardingsphere](http://shardingsphere.apache.org); [skywalking](http://skywalking.apache.org); [weex](http://weex.apache.org); [zipkin](http://zipkin.apache.org)|
@@ -375,7 +375,7 @@ There is a complete summary of the [member LDAP group](http://home.apache.org/co
 | remm | Remy Maucherat | [Jakarta](http://jakarta.apache.org/)|
 | reschke | Julian Reschke |
 | rfrovarp | Richard Frovarp |
-| rgielen | [René Gielen](http://twitter.com/rgielen) | [Struts](http://struts.apache.org)|
+| rgielen | [René Gielen](https://twitter.com/rgielen) | [Struts](https://struts.apache.org)|
 | rgoers | Ralph Goers | [Cocoon](http://cocoon.apache.org/) , [Commons](http://commons.apache.org/) , [Logging](http://logging.apache.org/) , [Maven](http://maven.apache.org/) , [Portals](http://portals.apache.org/)|
 | rhillegas | Rick Hillegas | [Derby](http://db.apache.org/derby/)|
 | rhuijben | Bert Huijben | [Subversion](http://subversion.apache.org/)|
@@ -476,7 +476,7 @@ There is a complete summary of the [member LDAP group](http://home.apache.org/co
 | woonsan | [Woonsan Ko](http://woonsanko.blogspot.com/) | [Portals](https://portals.apache.org/) , [Commons](https://commons.apache.org/) , [FreeMarker](https://freemarker.apache.org/)|
 | wrowe | William A. Rowe, Jr. | [httpd](http://httpd.apache.org/) ; [APR](http://apr.apache.org/) ; [httpd-docs](http://httpd.apache.org/docs-project/)|
 | wsanchez | [Wilfredo Sánchez](http://www.mit.edu/people/wsanchez/) |  [httpd](http://httpd.apache.org/) ; [APR](http://apr.apache.org/)|
-| wsmoak | [Wendy Smoak](http://www.wendysmoak.com) |  [Struts](http://struts.apache.org/) ; [MyFaces](http://myfaces.apache.org/) ; [Shale](http://shale.apache.org/)|
+| wsmoak | [Wendy Smoak](http://www.wendysmoak.com) |  [Struts](https//struts.apache.org/) ; [MyFaces](http://myfaces.apache.org/) ; [Shale](http://shale.apache.org/)|
 | wwei | [Weiwei Yang](https://yangwwei.github.io) | [Hadoop](https://hadoop.apache.org), [Ozone](https://ozone.apache.org), [YuniKorn](https://yunikorn.apache.org) |
 | xinwang | [Xin Wang](https://people.apache.org/~xinwang/) | [Storm](https://storm.apache.org/) , [RocketMQ](https://rocketmq.apache.org/) , [IoTDB](https://iotdb.apache.org/) , [StreamPipes](https://streampipes.apache.org/) , [Incubator](https://incubator.apache.org/) |
 | xuefu | Xuefu Zhang | [Hive](http://hive.apache.org) ; [Pig](http://pig.apache.org) |
@@ -635,7 +635,7 @@ There is a complete summary of the [member LDAP group](http://home.apache.org/co
 | minchau | Brian James Minchau |
 | mmarinschek | Martin Marinschek |
 | morgand | [Morgan Delagrange](http://home.apache.org/~morgand/) |
-| mrdon | Don Brown | [Struts](http://struts.apache.org/) , [Jakarta](http://jakarta.apache.org/)|
+| mrdon | Don Brown | [Struts](https://struts.apache.org/) , [Jakarta](http://jakarta.apache.org/)|
 | mriou | [Matthieu Riou](http://offthelip.org) |
 | mwomack | Mark Dwayne Womack |
 | nicolaken | Nicola Ken Barozzi |


### PR DESCRIPTION
Use https endpoint for struts.apache.org and some developer references.