### PR TITLE
Add `security.txt`

### DIFF
--- a/content/.well-known/security.txt
+++ b/content/.well-known/security.txt
@@ -1,0 +1,7 @@
+Contact: https://apache.org/security/
+Policy: https://apache.org/security/
+
+# https://www.apache.org/foundation/policies/conduct#diversity-statement
+Preferred-Languages: en
+
+Expires: 2024-06-19T00:00:00Z


### PR DESCRIPTION
As per https://www.rfc-editor.org/rfc/rfc9116

This makes it easier for security researchers to find out how to report potential issues to us.

Linking to https://www.apache.org/security/ instead of directly to our email addresses to encourage people to read about the ASF and our policies before engaging, and to somewhat avoid spam-y reports.

Hardcoding the expiry date is a bit awkward, but the whole point of that (required) field is to make sure someone reviews the information is still accurate from time to time, so confirming that by updating the expiry date might not be terrible (and the alternative, dynamically updating it somehow, seems worse).