### PR TITLE
Blank lines affect output adversely

### DIFF
--- a/content/index.ezmd
+++ b/content/index.ezmd
@@ -66,17 +66,14 @@ bodytag: id="home"
 	on <a href="https://feathercast.apache.org/">Feathercast</a>, the voice of the ASF.</p>
  <!-- gm -->
      <div class="updates">
-<!-- 
+<!--
         <article class="card">
         <div class="content">
            <span class="label label-danger">Twitter</span>
-<div>
-
-[[]@TheASF](https://twitter.com/TheASF)[for twitter] [twitter.text][end]
-
-</div>
+           <div>
+             [[]@TheASF](https://twitter.com/TheASF)[for twitter] [twitter.text][end]
+           </div>
          </div>
-
          <a class="continue" href="https://twitter.com/TheASF">Continue Reading&nbsp;&rarr;</a>
        </article>
 -->


### PR DESCRIPTION
The intention of commit d44fc5b was to disable the Twitter card, however it has also caused the Blogs and Conference cards to disappear. Compare [1] and [2].

It seems that blank lines cause issues for commented-out code.

This patch removes the blank lines and aligns tags.
I have applied it to preview/tags to show that it works [3].

[1] https://www.apache.org/#latest-news
[2] https://www-previous.staged.apache.org/#latest-news
[3] https://www-tags.staged.apache.org/#latest-news