### PR TITLE
Restore original link as it has more info

### DIFF
--- a/content/foundation/how-it-works/index.md
+++ b/content/foundation/how-it-works/index.md
@@ -296,7 +296,7 @@ nature of the various communities.
 
 Each project is responsible for its own [project website](https://home.apache.org/committers-by-project.html).
 Further information to assist committers, developers, and PMCs is available
-at [ASF Infrastructure](https://infra.apache.org/).
+at [ASF Infrastructure](/dev/).
 
 ### Decision Making  {#decision-making}
 


### PR DESCRIPTION
The section https://www-previous.staged.apache.org/foundation/how-it-works.html#documentation used to point to https://www-previous.staged.apache.org/dev/.

This has additional useful info which is not present in the new link, i.e. https://infra.apache.org/