### PR TITLE
Implement suggestion from Nico Roeser to press@

### DIFF
--- a/content/licenses/LICENSE-2.0.md
+++ b/content/licenses/LICENSE-2.0.md
@@ -137,17 +137,16 @@ and do not modify the License. You may add Your own attribution notices
 within Derivative Works that You distribute, alongside or as an addendum to
 the NOTICE text from the Work, provided that such additional attribution
 notices cannot be construed as modifying the License.
-<br/>
-<br/>
-You may add Your own copyright statement to Your modifications and may
+</li>
+
+</ol>
+
+<p>You may add Your own copyright statement to Your modifications and may
 provide additional or different license terms and conditions for use,
 reproduction, or distribution of Your modifications, or for any such
 Derivative Works as a whole, provided Your use, reproduction, and
 distribution of the Work otherwise complies with the conditions stated in
-this License.
-</li>
-
-</ol>
+this License.</p>
 
 <p><strong><a name="contributions">5. Submission of Contributions</a></strong>. Unless You
 explicitly state otherwise, any Contribution intentionally submitted for


### PR DESCRIPTION
full text of the suggestion

```
The text version <https://www.apache.org/licenses/LICENSE-2.0.txt> and the HTML presentation <https://www.apache.org/licenses/LICENSE-2.0> of the Apache License, Version 2.0 have a difference in markup which I feel should be remedied. (I am aware that it’s the _text_ what counts, not indentation and such – still there is room for improvement.)

Section “4. Redistribution.” contains a list with four items/paragraphs, followed by a further paragraph, which says “You may add Your own copyright statement […]”. This text about the copyright statement is not part of the list in the text version of the license; instead, it follows the list. In the HTML document, the text has been made part of the fourth list item. This is semantically incorrect: it talks about redistribution (i.e., belongs to section 4. of course), but is not a condition for redistribution – and particularly is not related to the “NOTICE” text file.

My suggestion: remove the br elements separating the “NOTICE” text from the text about adding copyright statements, move the latter out of the ol element, and put the text in a p element after the closing ol tag. Do you agree?

This will improve the HTML presentation of the license, and make it more closely resemble the text version (which developers and many users consider canonical, even though it maybe does not matter).
```