### PR TITLE
Remove "Trademark Policy" menu item

### DIFF
--- a/theme/apache/templates/base.html
+++ b/theme/apache/templates/base.html
@@ -125,7 +125,6 @@ s=d.getElementsByTagName('script')[0];
                 <li><a href="/foundation/how-it-works">How the ASF Works</a></li>
                 <li><a href="/theapacheway/">The Apache Way</a></li>
                 <li><a href="/legal/">Legal &amp; Trademark</a></li>
-                <li><a href="/foundation/marks/">Trademark Policy</a></li>
                 <li><a href="/licenses">Licenses</a></li>
                 <li><a href="/foundation/glossary">Glossary</a></li>
                 <li><a href="/foundation/faq">FAQ</a></li>


### PR DESCRIPTION
Removing Trademark Policy menu item, due to redundancy with "Legal & Trademark" item and, accoridng to analytics, very few people are coming into the Trademark page via this menu item.