### PR TITLE
Missing commit emails

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -18,6 +18,17 @@ notifications:
     "content/foundation/marks/*":
       - legal-discuss@apache.org
       - trademarks@apache.org
+    "content/foundation/marks/events.*": events-commits@apache.org
+    "content/foundation/policies/anti-harassment.*": events-commits@apache.org
+    "content/foundation/press/*": press@apache.org
+    "content/foundation/contributing.*": press@apache.org
+    "content/foundation/thanks.*": press@apache.org
+    "content/foundation/sponsorship.*": press@apache.org
+    "content/foundation/buy_stuff.*": press@apache.org
+    "content/press/*": press@apache.org
+    "content/security/*": security@apache.org
+    "content/foundation/board/*": board-cvs@apache.org
+    "content/board/*": board-cvs@apache.org
 
 pelican:
   notify: site-cvs@apache.org


### PR DESCRIPTION
These were implemented starting here:

https://github.com/apache/infrastructure-p6/blob/fe0691e702b6a24405bf32d1a80edfb20beebc2e/modules/subversion_server/files/authorization/asf-mailer.conf#L639