### PR TITLE
adding link targret offset

### DIFF
--- a/content/css/styles.css
+++ b/content/css/styles.css
@@ -13,6 +13,9 @@ h1, h2, h3, h4, h5, h6 {
   font-weight: 600;
 }
 
+:target {
+ scroll-margin-top: 50px;
+}
 h1 {
   font-size: 38px;
 }


### PR DESCRIPTION
Fixing issue [298](https://github.com/apache/www-site/issues/298)

The increased height of the header was causing anchor link targets to be covered.  I added a css fix to increase the offset of the target.

@bproffitt @loganloganlogan 