### PR TITLE
Exclude siteindex and 404 page from search results

### DIFF
--- a/content/404.ezmd
+++ b/content/404.ezmd
@@ -1,7 +1,7 @@
 title: 404
 bodytag: id="404"
 
-<section>
+<section data-pagefind-ignore="all">
   <div class="container">
      <div class="row">
 		<div class="col-sm-12 text-center">

--- a/theme/apache/templates/siteindex.html
+++ b/theme/apache/templates/siteindex.html
@@ -1,5 +1,7 @@
 {% extends "base.html" %}
 {% block content %}
+<section data-pagefind-ignore="all">
 {{ page.content }}
 {{ SITE_INDEX }}
+</section>
 {% endblock %}


### PR DESCRIPTION
Does not make sense to include siteindex and 404 page in the search index