### PR TITLE
Replace references to markmail.org with lists.apache.org

### DIFF
--- a/content/foundation/glossary.md
+++ b/content/foundation/glossary.md
@@ -689,8 +689,8 @@ Some definitions:
 -  [Naughty](http://www.urban75.com/Mag/troll.html) 
 -  [Definitive](http://en.wikipedia.org/wiki/Internet_trolls) 
      
-For how to deal with trolls, see [this thread](http://markmail.org/message/3wlpx2hafyeqdt4t) but (for those who
-are impatient) here's [Ted's opinion](http://markmail.org/message/sppexq2vcfewcm5a) 
+For how to deal with trolls, see [this thread](https://lists.apache.org/thread/wm9g4tlnf9j9c52t7syozx19fhxzd92z) but (for those who
+are impatient) here's [Ted's opinion](https://lists.apache.org/thread/z3h9w7mw8bs1gpy44vkyz9nht1bvhpbf)
 (which acts as a good summary).
 
 </dd>

--- a/content/foundation/mailinglists.md
+++ b/content/foundation/mailinglists.md
@@ -136,8 +136,6 @@ including:
 
 -  [Apache mail archives](https://lists.apache.org/) 
 
--  [MarkMail](http://apache.markmail.org/) 
-
 -  [MARC](http://marc.info/) 
 
 -  [mail-archive.com](http://mail-archive.com/) 

--- a/content/legal/ramblings.md
+++ b/content/legal/ramblings.md
@@ -105,7 +105,7 @@ licenses, new
 [clauses](http://mail-archives.apache.org/mod_mbox/www-legal-discuss/200803.mbox/%3c47DEB046.10004@dubioso.net%3e)
 , and new
 [exclusions](http://mail-archives.apache.org/mod_mbox/www-legal-discuss/200802.mbox/%3cE1A2049F-5D7B-44F7-A1E3-B9645BC52348@yahoo.com%3e).
-And new [uses](http://markmail.org/message/7no3tdx6nh37stpw).
+And new [uses](https://lists.apache.org/thread/wk1dskb4h2dzo5t71wyz5lgf0pc23hx4).
 
 ### Approximation 3  {#head-cc4186e2c34505e5dddc5c9b5e40a655cd699e5c}
 

--- a/content/security/committers.md
+++ b/content/security/committers.md
@@ -98,7 +98,7 @@ vulnerability.
 11. The project team documents the details of the vulnerability and the fix on the
 internal portal. The portal generates draft announcement texts.  For
 an example of an announcement see [Tomcat's announcement of
-CVE-2008-2370](https://markmail.org/message/w7mdjdxeqius7d6l). The
+CVE-2008-2370](https://lists.apache.org/thread/smbdmck5m48rbh6tw9bbfszf64oh591y). The
 level of detail to include in the report is a matter of
 judgement. Generally, reports should contain enough information to
 enable people to assess the risk the vulnerability poses for


### PR DESCRIPTION
I couldn't find an authorative reference, but it seems markmail.org has been permanently shut down

https://news.ycombinator.com/item?id=37230221