### PR TITLE
Tweaking the security site

### DIFF
--- a/content/security/committers.md
+++ b/content/security/committers.md
@@ -54,11 +54,9 @@ security nature of the commit.
 
 ### Report
 
-1. The person discovering the issue, the _reporter_, reports the
-vulnerability privately to `security@project.apache.org` or to
-`security@apache.org`.
+1. The person discovering the issue, the _reporter_, identifies the mailing list to report to. If the project the issue relates to has a security@*[project]*.apache.org mailing list listed on [security projects list](https://security.apache.org/projects/), use that mailing list. Otherwise, use `security@apache.org`.
 
-2. The Security team ignores any message to this inbox that does not relate to reporting or managing an
+2. Note that the Security teams will ignore all messages that do not relate to reporting or managing an
 undisclosed security vulnerability in Apache software.
 
 3. If the report comes to `security@apache.org`, the security team forwards
@@ -66,17 +64,21 @@ it to the project's security list or, if the project does not
 have a security list, to the project's private (PMC) mailing list.
 The Security Team responds to the original reporter that they have done this.
 
+4. If the project does not have a dedicated `security@project.apache.org`
+mailing list, all further communication regarding the vulnerability should be copied to `security@apache.org`. There is no need to do this for messages
+sent to `security@project.apache.org` since these are automatically copied to `security@apache.org`.
+
 ### Acknowledge
 
-4. The project team sends an e-mail to the original reporter to acknowledge the report, with a copy to `security@project.apache.org` if it exists, or to
-`security@apache.org`.
+4. The project team sends an e-mail to the original reporter to acknowledge the report, with a copy to the relevant security mailing list.
 
-5. The project team investigates the report and either rejects or accepts
-it.
+5. The project team investigates the report and either rejects or accepts it.
+
+6. Project team members may share information about the vulnerability with domain experts (including colleagues at their
+employer) at the discretion of the project's security team, providing that they make clear that the information is not for public disclosure.
 
 6. If the project team **rejects** the report, the team writes to the reporter to
-explain why, with a copy to `security@project.apache.org` if it exists, or to
-`security@apache.org`.
+explain why, with a copy to the relevant security mailing list.
 
 7. If the project team **accepts** the report, the team writes to the reporter to let them
 know that they have accepted the report and that they are working on a fix.
@@ -147,16 +149,6 @@ This is the first point that any information regarding the vulnerability is made
     This notifies the security team, which will submit the information to the CVE project.
 
 19. If the project repository is in Subversion, add the CVE ID to the log for the commit that applied the fix. Do **not** try to do this if your project uses a Git repository, as editing a pushed commit causes all sorts of problems.
-
-If the project does not have a dedicated `security@project.apache.org`
-mailing list, copy all communication regarding the vulnerability to `security@apache.org`. There is no need to do this for messages
-sent to `security@project.apache.org` since these are automatically copied to
-`security@apache.org`.
-
-Share information about the vulnerability with domain experts (or colleagues at your
-employer) at the discretion of the project's security team, providing that
-you make clear that the information is not for public disclosure and that you copy to
-`security@apache.org` or the project's security mailing list any communication regarding the vulnerability.
 
 <h2 id="ids">CVE IDs<a class="headerlink" href="#ids" title="Permanent link">&para;</a></h2>
 

--- a/content/security/index.md
+++ b/content/security/index.md
@@ -94,3 +94,7 @@ to resolve the vulnerability.
 
 Committers should read a [more detailed description of the process](committers.html). Reporters of security vulnerabilities may also find
 it useful.
+
+## Discussion
+
+Committers and Security Researchers are encouraged to join our [community discuss list](https://lists.apache.org/list.html?security-discuss@community.apache.org).


### PR DESCRIPTION
Two changes:

1. Adding a link to security-discuss@ to the front page.
2. The page discussing the vulnerability reporting had two paragraphs at the end that had gotten orphaned. I've made a go at incorporating them into the main text.