### PR TITLE
HTTP=>HTTPS is done by container host

### DIFF
--- a/content/.htaccess
+++ b/content/.htaccess
@@ -1,6 +1,4 @@
 RewriteEngine On
-RewriteCond %{HTTPS} off
-RewriteRule (.*) https://%{HTTP_HOST}%{REQUEST_URI} [R=301,L]
 RewriteRule ^/(.+)\.html$ /$1 [R=301,L]
 Redirect Permanent /foundation/martin.html /memorials/martin_poeschl.html
 


### PR DESCRIPTION
The rewrite is not necessary (indeed won't be triggered) as all requests have already been converted to https by the TLP container host.

For example, try the preview at:
http://www-nohttps.staged.apache.org/

Whilst it does not change the behaviour of the live site, having the rewrite makes local testing of htaccess files harder.

Local testing rarely uses or needs https, and it is complicated to set up.
Pelican has a server function, but that does not support htaccess files, and if it did, one would need to use https anyway.

Sample curl output:
$ curl -I http://www-nohttps.staged.apache.org/
HTTP/1.1 301 Moved Permanently
Date: Wed, 01 Nov 2023 13:03:49 GMT
Server: Apache
Location: https://www-nohttps.staged.apache.org/