### PR TITLE
Get rid of http links and replace link to deprecated advice for PMC

### DIFF
--- a/content/dev/pmc.md
+++ b/content/dev/pmc.md
@@ -117,7 +117,7 @@ maintain the confidentiality of messages on privately-archived mailing lists.
 ## How to perform the duties of the PMC chair  {#chair}
 
 See the [definition of PMC and chair](../foundation/how-it-works.html#pmc)
-, and be familiar with the [ASF Bylaws](../foundation/bylaws.html). The  [advice for new PMC chairs]( https://svn.apache.org/repos/private/foundation/officers/advice-for-new-pmc-chairs.txt) has additional useful information.
+, and be familiar with the [ASF Bylaws](../foundation/bylaws.html). The  [advice for new PMC chairs](/pmc-chair.html) has additional useful information.
 
 ### Review board meeting minutes about their project
 PMC chairs should monitor the minutes of board meetings for entries that are relevant to their 
@@ -218,7 +218,7 @@ will send a reply-all response to `board@`.
 
 ### Why would a project move to the Attic?  {#move-to-attic}
 
-As described on [its homepage](http://attic.apache.org), the Attic is meant
+As described on [its homepage](https://attic.apache.org), the Attic is meant
 to _provide oversight for projects which otherwise would not have oversight_.
 
 It's fine for ASF projects to be mature and quiet, with little development
@@ -644,7 +644,7 @@ There are two main ways to check the membership of PMCs and LDAP groups:
   - Committers can view, and PMC chairs can update, PMC rosters using 
 [Whimsy](https://whimsy.apache.org/roster/committee/).
   - Anyone may view Apache Phonebook pages at [https://home.apache.org/phonebook.html](https://home.apache.org/phonebook.html).
-From there you can link to a specific PMC like this: [home.apache.org/phonebook.html?pmc=gump](http://home.apache.org/phonebook.html?pmc=gump)
+From there you can link to a specific PMC like this: [home.apache.org/phonebook.html?pmc=gump](https://home.apache.org/phonebook.html?pmc=gump)
 
 Please allow time for any changes to LDAP and committee-info.txt to propagate to the Phonebook app.
 


### PR DESCRIPTION
… chair info

The linked advice is an empty file, thus can be replaced with the already published contents.
Apart from that I replaced some links that were http instead of https.