### PR TITLE
Removing 'test' from homepage title

### DIFF
--- a/content/index.ezmd
+++ b/content/index.ezmd
@@ -6,7 +6,7 @@ bodytag: id="home"
      <div class="row">
 		<div class="col-sm-12 text-center">
 			<div class="container public-good">
-				<h1 class="h3">Software for the Public Good test</h1>
+				<h1 class="h3">Software for the Public Good</h1>
 				<p>ASF’s open source software is used ubiquitously around the world with more than 8,400 committers contributing to more than 320 active projects.</p>
 				<p><a class="btn btn-default mx-10" href="/index.html#projects-list" role="button">See All Projects</a><a class="btn btn-default mx-10" href="https://community.apache.org/" role="button">Contribute</a></p>
 				<img class="img-responsive" src="img/Fo3uP-ZX0AMe1od.jpg" alt="Apache Everywhere" />


### PR DESCRIPTION
The home page has the word 'test' in a content title.

https://www.apache.org/#software-for-the-public-good-test
