### PR TITLE
Apply transitions to CSS stylings

### DIFF
--- a/content/css/styles.css
+++ b/content/css/styles.css
@@ -1,3 +1,7 @@
+* {
+   transition: all 0.3s;
+}
+
 body {
   font-family: 'Montserrat', 'Source Sans Pro','Helvetica Neue', Helvetica, Arial, sans-serif;
   font-weight: 300;


### PR DESCRIPTION
This PR adds a `0.3s` `transition` to all elements (unless otherwise defined). This will allow for smooth hover effects, and other transitions.

![ezgif-3-fdae67a040](https://github.com/apache/www-site/assets/38299977/b2022844-f681-4a45-abfe-1287d69b75e3)
> *<-- OLD / NEW -->*