### PR TITLE
Keep only Squash and merge button

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -3,6 +3,10 @@ github:
   features:
     # Enable issue management
     issues: true
+  enabled_merge_buttons:
+    squash: true
+    merge: false
+    rebase: false
 
 notifications:
   commits: site-cvs@apache.org


### PR DESCRIPTION
In https://github.com/apache/www-site/pull/362 we found intermediate merge commit can cause the commit history hard to read. Thus, I propose to leave only the "Squash and merge" button to make it clear that we always squash the whole PR into one commit on merging.