### PR TITLE
Remove RedBubble store mention and links

### DIFF
--- a/content/foundation/buy_stuff.md
+++ b/content/foundation/buy_stuff.md
@@ -5,11 +5,7 @@ license: https://www.apache.org/licenses/LICENSE-2.0
 
 The Apache Software Foundation licenses its trademarks and logos to a variety of entities that sell Apache-branded merchandise and contribute some or all of the profits to the Foundation. Those wishing to license the ASF and/or Apache Project logos for merchandising (swag, apparel, pins, stickers, etc.) may [contact ASF Brand Management](/foundation/marks/contact#swag) for further details.
 
-## SHOP
-
-![RedBubble](images/redbubble.png "RedBubble")
-
-The ASF has an [official store at RedBubble](https://www.redbubble.com/people/comdev/shop) that Apache Community Development (ComDev) runs. An array of products featuring dozens of Apache Project logos are available. To add your favorite Apache Project to this collection, submit a request to Mark Thomas (ASF VP Brand Management) by emailing [dev@community.apache.org](mailto:dev@community.apache.org).
+We used to have an online store for ASF merchandise, but as of May 2024 it's been closed and we do not have a replacement yet.
 
 Those interested in items from the ASF's earlier days and who want to contribute a portion of each sale's proceeds may find what they're looking for at:
 


### PR DESCRIPTION
As per @rbowen on #comdev Slack, the RedBubble store has been canceled.