### PR TITLE
Update to latest version of pagefind (1.1.0)

### DIFF
--- a/pagefind.sh
+++ b/pagefind.sh
@@ -28,12 +28,13 @@ set -e # fast exit (must be done after 'which' invocation)
 
 if [ -z "$PAGEFIND" ] # could not find pagefind
 then
-    echo "Download pagefind"
-    PAGEFIND_VERSION='1.0.3'
-    PAGEFIND_HASH='e84ec7e8cb424022aa70ca14e6735c67c9728596753321dec782a902c3bfe6f0'
+    PAGEFIND_VERSION='1.1.0'
+    PAGEFIND_HASH='b20d0b06b54eb2fba1e290245919376364584a456fb644e66eecdb67549b1cf2'
+    echo "Download pagefind ${PAGEFIND_VERSION}"
     BINDIR=$(mktemp -d)
     TARGET=${BINDIR}/pagefind.tar.gz
-    wget --no-verbose -O ${TARGET} https://github.com/CloudCannon/pagefind/releases/download/v${PAGEFIND_VERSION}/pagefind-v${PAGEFIND_VERSION}-x86_64-unknown-linux-musl.tar.gz
+    OS_TYPE=x86_64-unknown-linux-musl
+    wget --quiet -O ${TARGET} https://github.com/CloudCannon/pagefind/releases/download/v${PAGEFIND_VERSION}/pagefind-v${PAGEFIND_VERSION}-${OS_TYPE}.tar.gz
     echo "${PAGEFIND_HASH}  ${TARGET}" > ${TARGET}.sha256
     if shasum -a 256 -c ${TARGET}.sha256
     then

--- a/pagefind.sh
+++ b/pagefind.sh
@@ -34,7 +34,7 @@ then
     BINDIR=$(mktemp -d)
     TARGET=${BINDIR}/pagefind.tar.gz
     OS_TYPE=x86_64-unknown-linux-musl
-    wget --quiet -O ${TARGET} https://github.com/CloudCannon/pagefind/releases/download/v${PAGEFIND_VERSION}/pagefind-v${PAGEFIND_VERSION}-${OS_TYPE}.tar.gz
+    time wget --quiet -O ${TARGET} https://github.com/CloudCannon/pagefind/releases/download/v${PAGEFIND_VERSION}/pagefind-v${PAGEFIND_VERSION}-${OS_TYPE}.tar.gz
     echo "${PAGEFIND_HASH}  ${TARGET}" > ${TARGET}.sha256
     if shasum -a 256 -c ${TARGET}.sha256
     then


### PR DESCRIPTION
The current version of pagefind is now quite old (1.0.3).

The preview looks OK to me:

https://www-pagefind110.staged.apache.org/