### PR TITLE
Tautology on apache.org

### DIFF
--- a/content/foundation/individual-supporters.md
+++ b/content/foundation/individual-supporters.md
@@ -3,7 +3,7 @@ license: https://www.apache.org/licenses/LICENSE-2.0
 
 # Support ASF: Individual Giving Programs
 
-ASF’s open source software is used ubiquitously around the world. Individual Supporters enable the Apache Software Foundation to serve as the global home for hundreds of software projects, and to incubate the next-generation of open source innovations. We thank all current ASF Individual Supporters for their loyalty and contributions, and look forward to welcoming new donors as we continue to expand our community.
+The ASF’s open source software is used all around the world. Individual Supporters enable the Apache Software Foundation to serve as the global home for hundreds of software projects, and to incubate the next-generation of open source innovations. We thank all current ASF Individual Supporters for their loyalty and contributions, and look forward to welcoming new donors as we continue to expand our community.
 
 ## One-Time or Recurring Donations
 Giving to Apache is easy! You can donate with a debit or credit card, bank transfer, PayPal, or Google Pay. If you'd like to mail a check, see instructions below.  Donations are tax-deductible in the U.S. The ASF is recognized by <a href="https://www.charitynavigator.org/index.cfm?bay=search.profile&ein=470825376" target="_blank">Charity Navigator</a> and cited with the Gold Seal of Transparency by <a href="https://www.guidestar.org/profile/47-0825376" target="_blank">GuideStar</a>. Thank you in advance for your generosity!

--- a/content/index.ezmd
+++ b/content/index.ezmd
@@ -7,7 +7,7 @@ bodytag: id="home"
 		<div class="col-sm-12 text-center">
 			<div class="container public-good">
 				<h1 class="h3">Software for the Public Good</h1>
-				<p>ASF’s open source software is used ubiquitously around the world with more than 8,400 committers contributing to more than 320 active projects.</p>
+				<p>The ASF’s open source software is used all around the world with more than 8,400 committers contributing to more than 320 active projects.</p>
 				<p><a class="btn btn-default mx-10" href="/index.html#projects-list" role="button">See All Projects</a><a class="btn btn-default mx-10" href="https://community.apache.org/" role="button">Contribute</a></p>
 				<p><a href="/asf25years"><img class="img-responsive" src="img/anniversary-hero-twenty-five.jpg" alt="Apache 25 Year Anniversary" /></a></p>
 				<p>The ASF is celebrating its 25th anniversary. <a href="/asf25years">Learn more and participate</a></p>


### PR DESCRIPTION
These pages currently say:

"ASF’s open source software is used ubiquitously around the world ..."

This does not read well to me.

Firstly, "ubiquitously" means "everywhere", which means the same as
"around the world".

Secondly, the bare 'ASF' does not agree with the page title or the
logo, both of which use 'The ASF'