### PR TITLE
Correct the link for new PMC member to `newpmcmember` from `newpmc`

### DIFF
--- a/content/board/policies.md
+++ b/content/board/policies.md
@@ -32,7 +32,7 @@ and/or to the board.
 
   * Project discussions SHOULD use normal ASF-hosted dev@, user@, and similar mailing lists.
 
-  * Projects MAY use their own documented consensus process, or a VOTE, to decide on any [new committers](//www.apache.org/dev/pmc.html#newcommitter) or [PMC members](//www.apache.org/dev/pmc.html#newpmc).
+  * Projects MAY use their own documented consensus process, or a VOTE, to decide on any [new committers](//www.apache.org/dev/pmc.html#newcommitter) or [PMC members](//www.apache.org/dev/pmc.html#newpmcmember).
 
 ### Operate Independently And For The Public Good ([Board](https://whimsy.apache.org/foundation/orgchart/board))
 

--- a/content/dev/pmc.md
+++ b/content/dev/pmc.md
@@ -158,7 +158,7 @@ the new committer has [karma](#newcommitter) (access) to the project repositorie
 ### Send NOTICEs and followup when adding PMC members
 The chair is responsible for sending the NOTICE email to the board, then
 updating [committee-info.txt](https://svn.apache.org/repos/private/committers/board/committee-info.txt)
-and the LDAP committee group after the candidate accepts -- see the [detailed procedure](#newpmc).
+and the LDAP committee group after the candidate accepts -- see the [detailed procedure](#newpmcmember).
 
 ### Maintain ASF records on the PMC roster
 Maintain information about your PMC's composition in the SVN "committers" repository
@@ -284,7 +284,7 @@ See also [why would a project move to the Attic?](pmc.html#move-to-attic), above
 
 ## PMC membership management  {#pmcmembers}
 
-### How to add a PMC member  {#newpmc}
+### How to add a PMC member  {#newpmcmember}
 
 The usual process for adding a member to a PMC is to:
 

--- a/content/dev/project-requirements.md
+++ b/content/dev/project-requirements.md
@@ -36,7 +36,7 @@ ASF-wide policies, as well as for providing various services to all Apache proje
 
 * Project discussions SHOULD use normal ASF-hosted dev@, user@, and similar mailing lists.
 
-* Projects MAY use a documented consensus process or a VOTE for any [new committers](/dev/pmc.html#newcommitter) or [PMC members](/dev/pmc.html#newpmc), and carefully follow policies for recording ICLAs and granting access.
+* Projects MAY use a documented consensus process or a VOTE for any [new committers](/dev/pmc.html#newcommitter) or [PMC members](/dev/pmc.html#newpmcmember), and carefully follow policies for recording ICLAs and granting access.
 	
 # Technical  {#technical}
 

--- a/content/foundation/governance/pmcs.md
+++ b/content/foundation/governance/pmcs.md
@@ -60,7 +60,7 @@ accepts the offer of membership, the PMC chair may update the official roster
 of the members of that PMC. The process is designed to ensure that the board
 has explicit notification of all PMC changes. 
 
-For more details on the process, read [Adding a new PMC member](/dev/pmc.html#newpmc)
+For more details on the process, read [Adding a new PMC member](/dev/pmc.html#newpmcmember)
 
 For people leaving the PMC, read [A PMC member wishes to be resign/go emeritus. Now what?](/dev/pmc.html#emeritus)
 


### PR DESCRIPTION
There were a few documentation links (in comdev site mainly) that lined to #newpmc anchor, and since the links were shown verbatim in the page, they could be misunderstood - it was not about new PMC but about new PMC menber, and since we are now reminding projects that they should not invite "new PMC" but "new PMC member", correcting it in the link is a good thing to do.

Separate PR in comdev site corrects those links (and changes them to be replaced with "New PMC member" name.