### PR TITLE
New marketing category and add "creator" FAQ

### DIFF
--- a/content/foundation/faq.md
+++ b/content/foundation/faq.md
@@ -162,3 +162,13 @@ If you have sent us mail because you think you have traced spam to a system that
 
 - How to: Look up the owner of an IP address<small>(such as 10.0.35.147): [https://ws.arin.net/whois/](https://ws.arin.net/whois/). ARIN (Registered Internet Numbers) database (tells you who owns an IP address, such as 10.0.35.147, or which other database to query if the address is assigned outside the USA).
 
+## Marketing
+
+### Can I refer to an individual, organization or community as “founding” an ASF project? 
+Many projects enter the Apache Incubator with a recognized individual founder, group of founders, or corporate entity where the project originated and/or which was responsible for its development/administration. 
+
+The ASF is vendor neutral: all ASF projects are overseen by their respective Project Management Committees (PMCs), who guide the project's day-to-day operations. Once a project comes to the ASF, its development and oversight is the responsibility of the project’s PMC and community. 
+
+There are no "owners" of any Apache project. Individuals and companies who founded projects that are now under the auspices of the ASF may be referred to as "original creator of Apache Project Name" or "original developer of Apache Project Name." Examples: 
+* **Individual’s title.** "Individual’s Name, Apache Member (or Committer) and original developer of Apache Project Name." 
+* **Company whose founders or employees are the original creators of an Apache project.** "Company Name, founded by the original creators of Apache Project Name" or "several Company Name team members are the original developers of Apache Project Name."

--- a/content/foundation/faq.md
+++ b/content/foundation/faq.md
@@ -8,6 +8,7 @@ license: https://www.apache.org/licenses/LICENSE-2.0
 <a class="btn btn-default mx-10" href="#foundation" role="button">Foundation</a>
 <a class="btn btn-default mx-10" href="#members" role="button">Members</a>
 <a class="btn btn-default mx-10" href="#technical" role="button">Technical</a>
+<a class="btn btn-default mx-10" href="#marketing" role="button">Marketing</a>
 
 ## Software
 
@@ -164,11 +165,7 @@ If you have sent us mail because you think you have traced spam to a system that
 
 ## Marketing
 
-### Can I refer to an individual, organization or community as “founding” an ASF project? 
-Many projects enter the Apache Incubator with a recognized individual founder, group of founders, or corporate entity where the project originated and/or which was responsible for its development/administration. 
+### Can I refer to an individual or organization as the "founder" or "creator" of an ASF project?
+The ASF discourages this because it is detrimental to the long-term health of a project community to continually call attention to the individuals and/or organizations that originally created the project.
 
-The ASF is vendor neutral: all ASF projects are overseen by their respective Project Management Committees (PMCs), who guide the project's day-to-day operations. Once a project comes to the ASF, its development and oversight is the responsibility of the project’s PMC and community. 
-
-There are no "owners" of any Apache project. Individuals and companies who founded projects that are now under the auspices of the ASF may be referred to as "original creator of Apache Project Name" or "original developer of Apache Project Name." Examples: 
-* **Individual’s title.** "Individual’s Name, Apache Member (or Committer) and original developer of Apache Project Name." 
-* **Company whose founders or employees are the original creators of an Apache project.** "Company Name, founded by the original creators of Apache Project Name" or "several Company Name team members are the original developers of Apache Project Name."
+If it is necessary to highlight individuals and companies who founded a project that is now under the ASF’s stewardship, they may be referred to as "original creator of Apache Project Name" or "original developer of Apache Project Name."


### PR DESCRIPTION
The often asked question "Can I refer to an individual, organization or community as 'founding' an ASF project?" is currently on the Newsroom page. Because this is one of the more common brand violations that occur, it would make more sense to appear in the FAQ, which is a more logical place one might look. I'm proposing the addition to the FAQ, and will be proposing the deletion (and re-routing) to the Newsroom page if others agree. @markt-asf @justinmclean @bproffitt for input.
