### PR TITLE
Revert to previous version of pagefind

### DIFF
--- a/pagefind.sh
+++ b/pagefind.sh
@@ -51,4 +51,3 @@ fi
 
 echo "Running pagefind on ${PELICAN_OUTPUT_PATH}"
 ${PAGEFIND} --site ${PELICAN_OUTPUT_PATH} --output-subdir "_pagefind"
-


### PR DESCRIPTION
The current pagefind app (1.1.0) generates variable output data for the same input.
This results in spurious changes to the website and in the commit emails.

This PR reverts to the previous version (1.0.4), which has much more stable output.

Note that the change to 1.1.0 was not done to fix any problems, merely it seemed best to use the latest version.