### PR TITLE
security: better id for section on non-issues

### DIFF
--- a/content/security/index.md
+++ b/content/security/index.md
@@ -39,7 +39,7 @@ Please send one plain-text, unencrypted, email for each vulnerability you are re
 ask you to resubmit your report if you send it as an image, movie, HTML, or
 PDF attachment when you could as easily describe it with plain text.
 
-## Issues not considered as security vulnerabilities {#known-issues}
+## Issues not considered as security vulnerabilities {#non-issues}
 
 These are things that we are well aware of, and have been reported to us many
 times, but we do not class as a security vulnerability.


### PR DESCRIPTION
these are 'known not to be issues', so I think 'non-issues' fits better than 'known-issues'.

(this will break old links to this section, but in a pretty mild way)