### PR TITLE
Add Plus One to homepage + other card updates

### DIFF
--- a/content/index.ezmd
+++ b/content/index.ezmd
@@ -97,20 +97,16 @@ bodytag: id="home"
 					<img class="img-responsive" src="img/2021-report.jpg" alt="Apache Annual Report" />
 					<div class="card-content">
 						<h4>Reports</h4>
-						<p>Official ASF reports and statements,
-						 including Quarterly and Annual Reports, Vision Statement,
-						 "Apache is Open", 5-Year Strategic Plan, and more.</p>
+						<p>Read official ASF reports and statements from the ASF including annual reports, diversity reports, and more.</p>
 					</div>
 				</a>
 			</article>
 			<article class="card">
-				<a href="http://community.apache.org/">
-					<img class="img-responsive" src="img/community.jpg" alt="The Apache Community" />
+				<a href="https://news.apache.org/foundation/entry/asf-plus-one-newsletter-october-2024">
+					<img class="img-responsive" src="img/plusonenewsletter_card.jpg" alt="Plus One Newsletter" />
 					<div class="card-content">
-						<h4>Community</h4>
-						<p>Guidance and mentoring for those interested in participating in Apache projects and their communities.
-							From Google Summer of Code to community events, get started here to learn how to become an
-							Apache contributor.</p>
+						<h4>Plus One Newsletter</h4>
+						<p>Plus One is the ASF's monthly bulletin to showcase major milestones, news, events, and activities across the ASF project ecosystem. At the bottom of the blog, you can subscribe to get real-time notifications when a new edition is released.</p>
 					</div>
 				</a>
 			</article>
@@ -125,12 +121,11 @@ bodytag: id="home"
 				</a>
 			</article>
 			<article class="card">
-				<a href="https://apachecon.com/">
+				<a href="https://communityovercode.org/">
 					<img class="img-responsive" src="img/ApacheCon.jpg" alt="ApacheCon" />
 					<div class="card-content">
-						<h4>Conferences</h4>
-						<p>"Tomorrow's Technology Today" since 1998. Intentionally intimate, offering unparalleled educational,
-							networking, and collaboration opportunities.</p>
+						<h4>Community Over Code</h4>
+						<p>"Community Over Code - or C/C - is our annual flagship conference offering unparalleled educational, networking, and collaboration opportunities.</p>
 					</div>
 				</a>
 			</article>


### PR DESCRIPTION
Updated the "cards" section with:

The Plus One newsletter (replacing the Community card as it's duplicative of the updated navigation).

And:

Updated copy for the Reports section to remove quarterly reports and other outdated info.

Updated Conferences card to focus on Community Over Code and replace the apachecon link with C/C link.

cc @bproffitt for approval