### PR TITLE
Clarify sentence regarding document submission per email.

### DIFF
--- a/content/licenses/contributor-agreements.md
+++ b/content/licenses/contributor-agreements.md
@@ -86,8 +86,7 @@ file by preparing a detached PGP signature. For example,
 
 This will create a file named `icla.pdf.asc`. 
 
-Send both the file (icla.pdf) and the signature (icla.pdf.asc) as attachments in the same email to secretary@apache.org. Send only one 
-document (file plus signature) per email. 
+Send both the file (icla.pdf) and the signature (icla.pdf.asc) as attachments in the same email to secretary@apache.org.  Please send only one complete document (file plus signature) in each email. 
 
 Do not submit your **public key** to Apache. Instead, upload your public key to `keyserver.ubuntu.com`.
 


### PR DESCRIPTION
The sentence "Send only one document (file plus signature) per email." was unclear to some readers. This change clarifies that each email should contain one complete document, including both the file and signature.

The updated sentence is:
"Please send only one complete document (file plus signature) in each email."

This revision ensures that contributors better understand how to submit their documents