### PR TITLE
Improve reference to voting rules from the voting process page

### DIFF
--- a/content/foundation/glossary.md
+++ b/content/foundation/glossary.md
@@ -178,6 +178,8 @@ The official developer and user conference of the ASF (see the
 'Consensus approval' refers to a [vote](#Vote) (sense 1) which has
 completed with **at least three binding +1 votes** and **no** 
 [vetos](#Veto). Compare [Majority Approval](#MajorityApproval).
+Also see see [Lazy Consensus](#LazyConsensus),
+and the description of the [voting process](voting.html).
 
 </dd>
 
@@ -366,9 +368,9 @@ technical contributions.")
 (Also called 'lazy approval'.) A decision-making policy which assumes
 general consent if no responses are posted within a defined period.
 For example, "I'm going to commit this by lazy consensus if no-one
-objects within the next three days." Also see [Consensus Approval](#ConsensusApproval) ,
-[Majority Approval](#MajorityApproval) , and the description of the [voting
-process](voting.html).
+objects within the next three days." Also see [Consensus Approval](#ConsensusApproval),
+[Majority Approval](#MajorityApproval), and the description of the
+[voting process](voting.html).
 
 </dd>
 
@@ -385,11 +387,14 @@ license text).
 
 <dd>
 
-Refers to a [vote](#Vote) (sense 1) which has completed with
-more +1 votes than -1 votes. Note that in votes requiring
-majority approval a -1 vote is simply a vote against, **not** a [veto](#Veto).
+Refers to a [vote](#Vote) (sense 1) which has completed with **at
+least three binding +1 votes** and more +1 votes than -1 votes. (
+*I.e.* , a simple majority with a minimum quorum of three positive
+votes.) Note that in votes requiring majority approval a -1 vote is
+simply a vote against, **not** a [veto](#Veto).
 Compare [Consensus Approval](#ConsensusApproval).
-See also the description of the [voting process](voting.html).
+Also see see [Simple Majority](#SimpleMajority),
+and the description of the [voting process](voting.html).
 
 </dd>
 
@@ -641,6 +646,19 @@ Software Foundation.
 <dd>
 
 See [ReviewThenCommit](#ReviewThenCommit)
+
+</dd>
+
+<dt>Simple Majority  {#SimpleMajority}</dt>
+
+<dd>
+
+Refers to a [vote](#Vote) (sense 1) which has completed with
+more +1 votes than -1 votes. Note that in votes requiring
+majority approval a -1 vote is simply a vote against, **not** a [veto](#Veto).
+Compare [Lazy Consensus](#LazyConsensus).
+Also see see [Majority Approval](#MajorityApproval),
+and the description of the [voting process](voting.html).
 
 </dd>
 

--- a/content/foundation/glossary.md
+++ b/content/foundation/glossary.md
@@ -385,13 +385,11 @@ license text).
 
 <dd>
 
-Refers to a [vote](#Vote) (sense 1) which has completed with **at
-least three binding +1 votes** and more +1 votes than -1 votes. (
-*I.e.* , a simple majority with a minimum quorum of three positive
-votes.) Note that in votes requiring majority approval a -1 vote is
-simply a vote against, **not** a [veto](#Veto). Compare
-[Consensus Approval](#ConsensusApproval). See also the description of the [voting
-process](voting.html).
+Refers to a [vote](#Vote) (sense 1) which has completed with
+more +1 votes than -1 votes. Note that in votes requiring
+majority approval a -1 vote is simply a vote against, **not** a [veto](#Veto).
+Compare [Consensus Approval](#ConsensusApproval).
+See also the description of the [voting process](voting.html).
 
 </dd>
 

--- a/content/foundation/governance/meetings.md
+++ b/content/foundation/governance/meetings.md
@@ -32,7 +32,7 @@ Immediately after the meeting, the new board takes office for their one-year ter
 
 ### How we tally member votes
 
-For a new member to be elected, they must receive more Yes votes than No votes from the Members who vote on their nomination, per our [bylaws 4.1][1].  Apache STeVe handles all vote tracking and tallies, with volunteer Members monitoring the process.  ASF Members handle the process of running and auditing votes privately.
+For a new member to be elected, they must receive at least three votes, and more Yes votes than No votes from the Members who vote on their nomination, per our [bylaws 4.1][1].  Apache STeVe handles all vote tracking and tallies, with volunteer Members monitoring the process.  ASF Members handle the process of running and auditing votes privately.
 
 Votes for new member candidates are secret; since the votes are about individual people, once the vote monitors have confirmed the result of the tallies, we do not share the results publicly.
 

--- a/content/foundation/governance/meetings.md
+++ b/content/foundation/governance/meetings.md
@@ -32,7 +32,7 @@ Immediately after the meeting, the new board takes office for their one-year ter
 
 ### How we tally member votes
 
-For a new member to be elected, they must receive at least three votes, and more Yes votes than No votes from the Members who vote on their nomination, per our [bylaws 4.1][1].  Apache STeVe handles all vote tracking and tallies, with volunteer Members monitoring the process.  ASF Members handle the process of running and auditing votes privately.
+For a new member to be elected, they must receive more Yes votes than No votes from the Members who vote on their nomination, per our [bylaws 4.1][1].  Apache STeVe handles all vote tracking and tallies, with volunteer Members monitoring the process.  ASF Members handle the process of running and auditing votes privately.
 
 Votes for new member candidates are secret; since the votes are about individual people, once the vote monitors have confirmed the result of the tallies, we do not share the results publicly.
 

--- a/content/foundation/voting.md
+++ b/content/foundation/voting.md
@@ -15,27 +15,30 @@ There are essentially three types of vote:
 
 1. Package releases
 
-Votes on **procedural issues** follow the common format of majority rule unless
-otherwise stated. That is, if there are more favourable votes than
-unfavourable ones, the issue is considered to have passed -- regardless of
+Votes on **procedural issues** follow [simple majority](glossary.html#SimpleMajority),
+the common format of majority rule, unless
+otherwise stated. That is, if there are more +1 votes than
+-1 ones, the issue is considered to have passed -- regardless of
 the number of votes in each category. (If the number of votes seems too
 small to be representative of a community consensus, the issue is typically
 not pursued. However, see the description of [lazy
 consensus](#LazyConsensus) for a modifying factor.)
 
-Votes on **code modifications** follow a different model. In this scenario, a
-negative vote constitutes a [veto](#Veto) , which the voting group (generally the PMC of a project) cannot override.
+Votes on **code modifications** follow [consensus approval](glossary.html#ConsensusApproval).
+In this scenario, a negative vote constitutes a [veto](#Veto),
+which the voting group (generally the PMC of a project) cannot override.
 Again, this model may be modified by a [lazy consensus](#LazyConsensus)
 declaration when the request for a vote is raised, but the full-stop nature
 of a negative vote does not change. Under normal (non-lazy consensus)
-conditions, the proposal requires three positive votes and no negative votes
+conditions, the proposal requires three +1 votes and no -1 votes
 in order to pass; if it fails to garner the requisite amount of support, it
 doesn't. Then the proposer either withdraws the proposal or modifies the code and resubmits it,
 or the proposal simply languishes as an open issue until someone gets around to removing it.
 
-Votes on whether a **package** is ready to release use yet a
-different mechanism: are there are least three binding votes in favour of
-the release? See the [release policy](../legal/release-policy.html#release-approval) 
+Votes on whether a **package** is ready to release use [majority approval](glossary.html#MajorityApproval),
+i.e., are there at least three binding +1 vote,
+and are there more positive than negative binding votes?
+See the [release policy](../legal/release-policy.html#release-approval) 
 for more information on voting and requirements for binding votes.
 
 ## Binding votes
@@ -110,7 +113,6 @@ expressing is Boolean: 'I approve/do not approve of this change.'
 
 Votes on whether a package is ready to release use
 [majority approval](glossary.html#MajorityApproval),
-with at least three binding +1 votes,
 i.e., at least three PMC members must vote affirmatively
 for release, and there must be more positive than negative binding votes.
 **Releases may not be vetoed.** 

--- a/content/foundation/voting.md
+++ b/content/foundation/voting.md
@@ -109,7 +109,8 @@ expressing is Boolean: 'I approve/do not approve of this change.'
 ### Votes on package releases  {#ReleaseVotes}
 
 Votes on whether a package is ready to release use 
-[majority approval](glossary.html#MajorityApproval) -- 
+[majority approval](glossary.html#MajorityApproval),
+plus a minimum quorum of three positive votes,
 i.e. at least three PMC members must vote affirmatively
 for release, and there must be more positive than negative votes.
 **Releases may not be vetoed.** 

--- a/content/foundation/voting.md
+++ b/content/foundation/voting.md
@@ -15,9 +15,8 @@ There are essentially three types of vote:
 
 1. Package releases
 
-Votes on **procedural issues** follow [simple majority](glossary.html#SimpleMajority),
-the common format of majority rule, unless
-otherwise stated. That is, if there are more +1 votes than
+Votes on **procedural issues** follow [simple majority](glossary.html#SimpleMajority)
+unless otherwise stated. That is, if there are more +1 votes than
 -1 ones, the issue is considered to have passed -- regardless of
 the number of votes in each category. (If the number of votes seems too
 small to be representative of a community consensus, the issue is typically

--- a/content/foundation/voting.md
+++ b/content/foundation/voting.md
@@ -108,11 +108,11 @@ expressing is Boolean: 'I approve/do not approve of this change.'
 
 ### Votes on package releases  {#ReleaseVotes}
 
-Votes on whether a package is ready to release use 
+Votes on whether a package is ready to release use
 [majority approval](glossary.html#MajorityApproval),
-plus a minimum quorum of three positive votes,
-i.e. at least three PMC members must vote affirmatively
-for release, and there must be more positive than negative votes.
+with at least three binding +1 votes,
+i.e., at least three PMC members must vote affirmatively
+for release, and there must be more positive than negative binding votes.
 **Releases may not be vetoed.** 
 Generally the community
 will cancel the release vote if anyone identifies serious problems, but

--- a/content/foundation/voting.md
+++ b/content/foundation/voting.md
@@ -58,7 +58,7 @@ However, **in no case** may someone's vote be considered
 invalid if it does not appear to meet the implied commitment: a vote is a
 formal expression of opinion, *not* of commitment.
 
-If the [R-T-C](#ReviewThenCommit) policy is in effect, a positive vote
+If the [R-T-C](glossary.html#ReviewThenCommit) policy is in effect, a positive vote
 carries the very strong implied message, 'I have tested this patch myself,
 and found it good.' Similarly, a negative vote usually means that that the voter tested
 the patch and found it to be *not* good, although the veto (for such it is
@@ -158,4 +158,3 @@ People tend to avoid conflict and thrash around looking for something to
 substitute - somebody in charge, a rule, a process, stagnation. None of
 these tend to be very good substitutes for doing the hard work of resolving
 the conflict.
-


### PR DESCRIPTION
In bylaws 4.1, it writes (https://www.apache.org/foundation/bylaws.html#4.1):

> ... members of the corporation shall be admitted as members of the corporation only by a majority vote of the existing members of the corporation ...

And our glossary writes (https://www.apache.org/foundation/glossary.html#MajorityApproval):

> Majority Approval
> Refers to a [vote](https://www.apache.org/foundation/glossary.html#Vote) (sense 1) which has completed with at least three binding +1 votes and more +1 votes than -1 votes.

So I'd try to keep the expression in sync to eliminate confusion. Not sure if it's a simple fact check or we should bring a discussion to the list.

cc @jvz 