### PR TITLE
Fixed the issue 412 ->Focus to glyphicon-search with necesaary delay

### DIFF
--- a/theme/apache/templates/base.html
+++ b/theme/apache/templates/base.html
@@ -199,6 +199,22 @@ s=d.getElementsByTagName('script')[0];
       </div>
     </nav>
   </header>
+     <!-- Script is to make the input field ready as soon as user click the search button-->
+      <!-- script could be simplyfy and shorten in length bootstrap framework  -->
+     <script>
+   document.addEventListener('DOMContentLoaded', function () {
+    // Using Bootstrap's event system for dropdowns
+    $(document).on('shown.bs.dropdown', '.dropdown', function () {
+        // Check if this is the search dropdown
+        if ($(this).find('.glyphicon-search').length > 0) {
+            // Find and focus the search input
+            setTimeout(function() {
+                $('.pagefind-ui__search-input').focus();
+            }, 50); // Small delay to ensure input is ready
+        }
+    });
+});
+  </script>
   <!-- / Navigation -->
   <header id="main-header" class="container">
     <div class="sideImg">


### PR DESCRIPTION
Issue -> #412 
Status -> Fixed , tested on local system
Follow ups -> #429 @sebbASF 
Approach(optimized) -> Added the focus to input field as soon as button is click (for rendering delay of 50ms is given as well ),
using Bootstrap's native event system to detect when the search dropdown opens and then automatically places the cursor in the search field. 

Proposed Issue -> When you want to search for something, you need to type a search text string. The search text needs to be entered in the search box that opens below the search button. But the cursor is still hovering over the search button so you cannot type into the search box.
Proposed Fix -> By clicking the search icon ,input fields auto focused .

https://github.com/user-attachments/assets/9d638362-b92e-485f-aa2d-77bda979ff21

