### PR TITLE
Add a section on "Expedited Releases" to the Release Policy

### DIFF
--- a/content/legal/release-policy.md
+++ b/content/legal/release-policy.md
@@ -58,7 +58,7 @@ ASF projects are made up of distributed teams, in multiple time zones and volunt
 with lives and jobs and the rationale behind 72 Hours is to try and give all
 members of a project the opportunity to take part in the decision to release.
 
-The most obvious example of an exceptional circustamce would be for a fix for a
+The most obvious example of an exceptional circumstance would be for a fix for a
 publicly known security issue. Everyone will probably have a different definition
 of what an exceptional circumstance is, but ultimately it is down to individual
 PMCs to decide for their project. 

--- a/content/legal/release-policy.md
+++ b/content/legal/release-policy.md
@@ -44,7 +44,37 @@ requirements of ASF policy on releases as described below, validate all
 cryptographic signatures, compile as provided, and test the result on their
 own platform.
 
-Release votes SHOULD remain open for at least 72 hours.
+Release votes SHOULD remain open for at least 72 hours. See
+[RFC 2119](https://www.rfc-editor.org/rfc/rfc2119) for a good definition of
+SHOULD and the next [Expedited Releases](#expedited-releases) section when
+considering a reduced voting period.
+
+#### Expedited Releases {#expedited-releases}
+As stated above, the normal policy for releases is to allow 72 hours for
+release reviews and votes, however the review/voting period for a release
+can be reduced in exceptional circumstances.
+
+ASF projects are made up of distributed teams, in multiple time zones and volunteers
+with lives and jobs and the rationale behind 72 Hours is to try and give all
+members of a project the opportunity to take part in the decision to release.
+
+The most obvious example of an exceptional circustamce would be for a fix for a
+publicly known security issue. Everyone will probably have a different definition
+of what an exceptional circumstance is, but ultimately it is down to individual
+PMCs to decide for their project. 
+
+Projects SHOULD give as much notice as possible for an expedited release in
+order to give project members a chance to make time to participate in the
+decision.
+
+Emails calling for a Release Vote that run for less than 72 hours SHOULD include
+an explanation of why the release is being expedited.
+
+This policy already states that deviations from normal policy MUST be reported to
+the Board, but it is worth emphasising this here specifically for release votes
+with a reduced voting time. Unless there are pressing reasons to inform the Board
+earlier, reporting can be done in the project's next scheduled board report.
+
 
 ### Publication  {#publication}
 

--- a/content/legal/release-policy.md
+++ b/content/legal/release-policy.md
@@ -59,7 +59,7 @@ with lives and jobs and the rationale behind 72 Hours is to try and give all
 members of a project the opportunity to take part in the decision to release.
 
 The most obvious example of an exceptional circumstance would be for a fix for a
-publicly known security issue. Everyone will probably have a different definition
+publicly known or critical, easily exploitable security issue. Everyone will probably have a different definition
 of what an exceptional circumstance is, but ultimately it is down to individual
 PMCs to decide for their project. 
 

--- a/content/legal/release-policy.md
+++ b/content/legal/release-policy.md
@@ -44,10 +44,9 @@ requirements of ASF policy on releases as described below, validate all
 cryptographic signatures, compile as provided, and test the result on their
 own platform.
 
-Release votes SHOULD remain open for at least 72 hours. See
-[RFC 2119](https://www.rfc-editor.org/rfc/rfc2119) for a good definition of
-SHOULD, and the next [Expedited Releases](#expedited-releases) section when
-considering a reduced voting period.
+Release votes SHOULD remain open for at least 72 hours. See the next
+[Expedited Releases](#expedited-releases) section when considering a reduced
+voting period.
 
 #### Expedited Releases {#expedited-releases}
 As stated above, the normal policy for releases is to allow 72 hours for

--- a/content/legal/release-policy.md
+++ b/content/legal/release-policy.md
@@ -46,7 +46,7 @@ own platform.
 
 Release votes SHOULD remain open for at least 72 hours. See
 [RFC 2119](https://www.rfc-editor.org/rfc/rfc2119) for a good definition of
-SHOULD and the next [Expedited Releases](#expedited-releases) section when
+SHOULD, and the next [Expedited Releases](#expedited-releases) section when
 considering a reduced voting period.
 
 #### Expedited Releases {#expedited-releases}
@@ -67,7 +67,7 @@ Projects SHOULD give as much notice as possible for an expedited release in
 order to give project members a chance to make time to participate in the
 decision.
 
-Emails calling for a Release Vote that run for less than 72 hours SHOULD include
+Emails calling for a Release Vote that run for less than 72 hours MUST include
 an explanation of why the release is being expedited.
 
 This policy already states that deviations from normal policy MUST be reported to

--- a/content/legal/release-policy.md
+++ b/content/legal/release-policy.md
@@ -55,7 +55,7 @@ release reviews and votes, however the review/voting period for a release
 can be reduced in exceptional circumstances.
 
 ASF projects are made up of distributed teams, in multiple time zones and volunteers
-with lives and jobs and the rationale behind 72 Hours is to try and give all
+with lives and jobs and the rationale behind 72 hours is to try and give all
 members of a project the opportunity to take part in the decision to release.
 
 The most obvious example of an exceptional circumstance would be for a fix for a


### PR DESCRIPTION
The following discussions on members@ talked about urgent releases where the voting period was less than the normal 72 hours:

- https://lists.apache.org/thread/v6ypw13s1r3zc6xmvbl10mzfgbcjw4xf
- https://lists.apache.org/thread/ks9r0t3x8w5k5fy707dhphgnt2k7j7nd

It is difficult to have a consensus on what an _exceptional_ circumstance is. No-one has disagreed with urgent releases for publicly know security issues. However there was agreement from a number of people (and no disagreement) on the following points:

- Explain why in the vote email
- give project members as much "heads up" as possible before the vote is called
- since its not following normal policy it must be reported to the board

I've tried to encapsulate that in a new section in the release policy doc. However I'm not the best wordsmith so please feel free to improve