### PR TITLE
More concise wording for expedited releases

### DIFF
--- a/content/legal/release-policy.md
+++ b/content/legal/release-policy.md
@@ -53,7 +53,8 @@ The review and voting period for a release can be reduced in
 exceptional circumstances.
 
 A typical example is a release that fixes publicly known or
-critical exploitable security issues.
+critical exploitable security issues, but the PMC can decide
+what constitutes an exceptional circumstance.
 
 PMCs SHOULD give as much notice as possible to their project members
 when doing an expedited release.

--- a/content/legal/release-policy.md
+++ b/content/legal/release-policy.md
@@ -46,6 +46,7 @@ own platform.
 
 Unless there are strong reasons to expedite a release, as described below,
 release votes SHOULD remain open for at least 72 hours, to give PMC members
+(volunteers spread around multiple time zones, with lives and jobs)
 enough time to participate.
 
 #### Expedited Releases {#expedited-releases}

--- a/content/legal/release-policy.md
+++ b/content/legal/release-policy.md
@@ -44,36 +44,26 @@ requirements of ASF policy on releases as described below, validate all
 cryptographic signatures, compile as provided, and test the result on their
 own platform.
 
-Release votes SHOULD remain open for at least 72 hours. See the next
-[Expedited Releases](#expedited-releases) section when considering a reduced
-voting period.
+Unless there are strong reasons to expedite a release, as described below,
+release votes SHOULD remain open for at least 72 hours, to give PMC members
+enough time to participate.
 
 #### Expedited Releases {#expedited-releases}
-As stated above, the normal policy for releases is to allow 72 hours for
-release reviews and votes, however the review/voting period for a release
-can be reduced in exceptional circumstances.
+The review and voting period for a release can be reduced in
+exceptional circumstances.
 
-ASF projects are made up of distributed teams, in multiple time zones and volunteers
-with lives and jobs and the rationale behind 72 hours is to try and give all
-members of a project the opportunity to take part in the decision to release.
+A typical example is a release that fixes publicly known or
+critical exploitable security issues.
 
-The most obvious example of an exceptional circumstance would be for a fix for a
-publicly known or critical, easily exploitable security issue. Everyone will probably have a different definition
-of what an exceptional circumstance is, but ultimately it is down to individual
-PMCs to decide for their project. 
+PMCs SHOULD give as much notice as possible to their project members
+when doing an expedited release.
 
-Projects SHOULD give as much notice as possible for an expedited release in
-order to give project members a chance to make time to participate in the
-decision.
-
-Emails calling for a Release Vote that run for less than 72 hours MUST include
+Emails calling for a Release Vote that runs for less than 72 hours MUST include
 an explanation of why the release is being expedited.
 
-This policy already states that deviations from normal policy MUST be reported to
-the Board, but it is worth emphasising this here specifically for release votes
-with a reduced voting time. Unless there are pressing reasons to inform the Board
-earlier, reporting can be done in the project's next scheduled board report.
-
+Expedited releases are deviations from normal policy, and as such MUST be reported
+to the Board, in the project's next scheduled Board report, unless the PMC wants
+to report earlier.
 
 ### Publication  {#publication}
 


### PR DESCRIPTION
Sorry that I missed the discussion in PR #457 - here's a more concise version of the expedited releases explanation. I _think_ it doesn't change the meaning, but hopefully says the same in a simpler way.

Preview at https://www-expedited-concise.staged.apache.org/legal/release-policy.html#expedited-releases