### PR TITLE
Tidy up .asf.yaml to allow for recent parser changes

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -1,9 +1,4 @@
-# See: https://cwiki.apache.org/confluence/display/INFRA/git+-+.asf.yaml+features
-
-# Workround for asfyaml newgen parsing bug
-meta:
-  prevgen: true
-
+# See: https://github.com/apache/infrastructure-asfyaml/blob/main/README.md
 github:
   features:
     # Enable issue management
@@ -54,6 +49,4 @@ staging:
   autostage: preview/*
 
 publish:
-  profile: ~
   whoami: asf-site
-


### PR DESCRIPTION
No need for minimum_page_count work-round any more
Drop profile from publish stanza (no longer tolerated by parser) 
Fix link to documentation

The recent .asf.yaml parser change caused various issues, which I hope have all been sorted now.
This PR is to remove the temporary work-round (reversion to the old parser).