### PR TITLE
Keep mailing list info up-to-date

### DIFF
--- a/content/dev/index.md
+++ b/content/dev/index.md
@@ -9,19 +9,18 @@ Here are resources pertinent to developers, committers, release managers and Pro
 
 If you can't find information here, ask on your project's mailing list, or contact the [Community Development](http://community.apache.org/) project's mailing list for more general questions. There are many experienced ASF people ready to help.
 
-- [Developer information](#developer-information)
-  - [Overview {#intro}](#overview-intro)
-  - [Apache Infrastructure  {#infrastructure}](#apache-infrastructure--infrastructure)
-  - [Committers and Contributors  {#committers}](#committers-and-contributors--committers)
-  - [Project Management Committees (PMCs)  {#pmc}](#project-management-committees-pmcs--pmc)
-  - [Licenses, Trademarks, and Legal issues  {#licenses}](#licenses-trademarks-and-legal-issues--licenses)
-  - [Version Control  {#version-control}](#version-control--version-control)
-  - [Apache Project Websites  {#web}](#apache-project-websites--web)
-  - [Software Product Releases  {#releases}](#software-product-releases--releases)
-  - [Issue and Bug Tracking  {#issues}](#issue-and-bug-tracking--issues)
-  - [Mailing Lists  {#mail}](#mailing-lists--mail)
-  - [Apache URL Shortener Service  {#shorten}](#apache-url-shortener-service--shorten)
-
+- [Infrastructure](#infrastructure)
+- [Committers and Contributors](#committers)
+  - [Pasting data to share with others](#paste)
+  - [URL shortener for committers](#shorten)
+- [Project Management Committees (PMC)](#pmc)
+  - [Version control](#version-control)
+  - [Websites](#web)
+  - [Releases](#releases)
+  - [Issue tracking](#issues)
+  - [Mailing lists](#mail)
+  - [Licenses and legal issues](#licenses)
+- [Board of Directors and ASF Governance](/foundation/governance/)
 
 ## Apache Infrastructure  {#infrastructure}
 

--- a/content/dev/index.md
+++ b/content/dev/index.md
@@ -9,18 +9,18 @@ Here are resources pertinent to developers, committers, release managers and Pro
 
 If you can't find information here, ask on your project's mailing list, or contact the [Community Development](http://community.apache.org/) project's mailing list for more general questions. There are many experienced ASF people ready to help.
 
-- [Infrastructure](#infrastructure)
-- [Committers and Contributors](#committers)
-  - [Pasting data to share with others](#paste)
-  - [URL shortener for committers](#shorten)
-- [Project Management Committees (PMC)](#pmc)
-  - [Version control](#version-control)
-  - [Websites](#web)
-  - [Releases](#releases)
-  - [Issue tracking](#issues)
-  - [Mailing lists](#mail)
-  - [Licenses and legal issues](#licenses)
-- [Board of Directors and ASF Governance](/foundation/governance/)
+- [Developer information](#developer-information)
+  - [Overview {#intro}](#overview-intro)
+  - [Apache Infrastructure  {#infrastructure}](#apache-infrastructure--infrastructure)
+  - [Committers and Contributors  {#committers}](#committers-and-contributors--committers)
+  - [Project Management Committees (PMCs)  {#pmc}](#project-management-committees-pmcs--pmc)
+  - [Licenses, Trademarks, and Legal issues  {#licenses}](#licenses-trademarks-and-legal-issues--licenses)
+  - [Version Control  {#version-control}](#version-control--version-control)
+  - [Apache Project Websites  {#web}](#apache-project-websites--web)
+  - [Software Product Releases  {#releases}](#software-product-releases--releases)
+  - [Issue and Bug Tracking  {#issues}](#issue-and-bug-tracking--issues)
+  - [Mailing Lists  {#mail}](#mailing-lists--mail)
+  - [Apache URL Shortener Service  {#shorten}](#apache-url-shortener-service--shorten)
 
 
 ## Apache Infrastructure  {#infrastructure}
@@ -117,11 +117,8 @@ Check the <a href="http://projects.apache.org/indexes/quick.html" target="_blank
 -  [Email etiquette tips for contributors](contrib-email-tips) 
 -  How to [moderate Apache mailing lists](committers.html#mail-moderate) 
 -  All Apache mailing lists are archived:
-    - Read most Apache [list archives on mail-archives.apache.org](http://mail-archives.apache.org/mod_mbox/) by going to the specific project list, then append the mbox filename to the URL (e.g. [mail-archives.apache.org/mod_mbox/httpd-dev/201210.mbox](mail-archives.apache.org/mod_mbox/httpd-dev/201210.mbox))
-    - Raw mbox archive files are available for every mailing list.
-    - Each project website has a "mail" directory, e.g. [httpd.apache.org/mail/](http://httpd.apache.org/mail/)
-(see [notes](/dev/project-site.html#mail)).
-    - For top-level/non-project mailing lists see [www.apache.org/mail/](/mail/) directory.
+    - For top-level/non-project mailing lists see [list archives on lists.apache.org](http://lists.apache.org/).
+    - Some projects have a "mail" directory at the top of their project website (see [notes](https://infra.apache.org/project-site.html#mail)).
 
 ## Apache URL Shortener Service  {#shorten}
 

--- a/content/dev/pmc.md
+++ b/content/dev/pmc.md
@@ -622,7 +622,6 @@ and officers may also read PMC mailing list archives. There
 are several ways to access our private archives:
 
 *   [lists.apache.org](https://lists.apache.org/), also called PonyMail, is the preferred archive system.
-*   [mail-search.apache.org](https://mail-search.apache.org/) is the older mod_mbox system.
 *   PMC members who are not also ASF Members can
     [fetch](/foundation/mailinglists.html) archives in the normal way: via the
     `-get` administrative command to ezmlm to download groups of mails.

--- a/content/foundation/how-it-works/index.md
+++ b/content/foundation/how-it-works/index.md
@@ -1,4 +1,3 @@
-Atom: http://mail-archives.apache.org/mod_mbox/www-community/?format=atom
 Title: How the ASF works
 Notice: http://www.apache.org/licenses/LICENSE-2.0
 
@@ -168,8 +167,8 @@ officers](/foundation/faq.html#why-are-PMC-chairs-officers).
 
 The [ASF Bylaws](/foundation/bylaws.html) (section 6.3) define a PMC and the position
 of chair. Some emails help to clarify:
-[here](http://www.mail-archive.com/community@apache.org/msg03961.html) and
-[here](http://www.mail-archive.com/community@apache.org/msg04005.html).
+[here](https://lists.apache.org/thread/cmjkjv56r5317lshh7bjr0jfpqpbm124) and
+[here](https://lists.apache.org/thread/x4vjvp01hj9nr6h96m9jv04mss0oyfoc).
 
 The role of the PMC from a Foundation perspective is oversight. The main
 role of the PMC is not code and not coding, but to ensure that its community addresses all legal

--- a/content/foundation/how-it-works/legal.md
+++ b/content/foundation/how-it-works/legal.md
@@ -1,5 +1,4 @@
 Title: ASF Development Process
-Atom: http://mail-archives.apache.org/mod_mbox/www-legal-discuss/?format=atom
 Notice: http://www.apache.org/licenses/LICENSE-2.0
 
 # {{title}}

--- a/content/foundation/mailinglists.md
+++ b/content/foundation/mailinglists.md
@@ -131,14 +131,13 @@ For further information, see the
 
 ## Mailing List Archives  {#archives}
 
-Archives for public mailing lists are available at a number of locations,
-including:
+Archives for public mailing lists are available at a number of locations.
+You can find the archives at [Apache mail archives](https://lists.apache.org/)
 
--  [Apache mail archives](https://lists.apache.org/) 
+Other thirdparty archives for public mailing lists are available at:
 
--  [MARC](http://marc.info/) 
-
--  [mail-archive.com](http://mail-archive.com/) 
+-  [MARC](http://marc.info/)
+-  [mail-archive.com](http://mail-archive.com/)
 
 ## Project Mailing Lists
 
@@ -171,12 +170,12 @@ You may also be interested in
 our official [@TheASF Twitter](https://twitter.com/TheASF) account, or the 
 [official ASF Blog](https://blogs.apache.org/foundation/).
 
-| Volume: | Low |
-|---------|-----|
-| Subscription address: |  [announce-subscribe@apache.org](mailto:announce-subscribe@apache.org)  |
-| Unsubscription address: |  [announce-unsubscribe@apache.org](mailto:announce-unsubscribe@apache.org)  |
-| Archives: | [Web archives](http://lists.apache.org/list.html?announce@apache.org)<br />[archives](http://www.mail-archive.com/announce@apache.org/) |
-| Getting help with the list: |  [announce-help@apache.org](mailto:announce-help@apache.org)  |
+| Volume:                     | Low                                                                       |
+| --------------------------- | ------------------------------------------------------------------------- |
+| Subscription address:       | [announce-subscribe@apache.org](mailto:announce-subscribe@apache.org)     |
+| Unsubscription address:     | [announce-unsubscribe@apache.org](mailto:announce-unsubscribe@apache.org) |
+| Archives:                   | [Web archives](http://lists.apache.org/list.html?announce@apache.org)     |
+| Getting help with the list: | [announce-help@apache.org](mailto:announce-help@apache.org)               |
 
 ## Apache Conference Announcements  {#foundation-apachecon}
 
@@ -186,36 +185,36 @@ and trade shows in which the Foundation is participating. Only the Foundation po
 You may also be interested in our official [@ApacheCon Twitter](https://twitter.com/ApacheCon) account, or the 
 [official ApacheCon Conferences blog](https://blogs.apache.org/conferences/).
 
-| Volume: | Very low |
-|---------|----------|
-| Subscription address: |  [announce-subscribe@ApacheCon.Com](mailto:announce-subscribe@ApacheCon.Com)  |
-| Unsubscription address: |  [announce-unsubscribe@ApacheCon.Com](mailto:announce-unsubscribe@ApacheCon.Com)  |
-| Archives: | Available back to 13 October 1999. Send a message to [announce-help@ApacheCon.Com](mailto:announce-help@ApacheCon.Com) for information about accessing the archives. |
-| Getting help with the list: |  [announce-help@ApacheCon.Com](mailto:announce-help@ApacheCon.Com)  |
+| Volume:                     | Very low                                                                                                                                                             |
+| --------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Subscription address:       | [announce-subscribe@ApacheCon.Com](mailto:announce-subscribe@ApacheCon.Com)                                                                                          |
+| Unsubscription address:     | [announce-unsubscribe@ApacheCon.Com](mailto:announce-unsubscribe@ApacheCon.Com)                                                                                      |
+| Archives:                   | Available back to 13 October 1999. Send a message to [announce-help@ApacheCon.Com](mailto:announce-help@ApacheCon.Com) for information about accessing the archives. |
+| Getting help with the list: | [announce-help@ApacheCon.Com](mailto:announce-help@ApacheCon.Com)                                                                                                    |
 
 ## Apache Conference Planning and Discussions  {#foundation-apachecon-discuss}
 
 The `apachecon-discuss@apache.org` mailing list is for discussions of the future of ApacheCon, and future 
 ApacheCons. (Discussions of current and upcoming ApacheCons which have been approved occur on other lists.)
 
-| Volume: | Moderate |
-|---------|----------|
-| Subscription address: |  [apachecon-discuss-subscribe@apache.org](mailto:apachecon-discuss-subscribe@apache.org)  |
-| Unsubscription address: |  [apachecon-discuss-unsubscribe@apache.org](mailto:apachecon-discuss-unsubscribe@apache.org)  |
-| Archives: | [Web archives](http://lists.apache.org/list.html?apachecon-discuss@apache.org) |
-| Getting help with the list: |  [apachecon-discuss-help@apache.org](mailto:apachecon-discuss-help@apache.org)  |
+| Volume:                     | Moderate                                                                                    |
+| --------------------------- | ------------------------------------------------------------------------------------------- |
+| Subscription address:       | [apachecon-discuss-subscribe@apache.org](mailto:apachecon-discuss-subscribe@apache.org)     |
+| Unsubscription address:     | [apachecon-discuss-unsubscribe@apache.org](mailto:apachecon-discuss-unsubscribe@apache.org) |
+| Archives:                   | [Web archives](http://lists.apache.org/list.html?apachecon-discuss@apache.org)              |
+| Getting help with the list: | [apachecon-discuss-help@apache.org](mailto:apachecon-discuss-help@apache.org)               |
 
 The `small-events-discuss@apache.org` mailing list is for discussions on future small events, such as 
 BarCampApaches, Meetups, Retreats and Hackathons. It is for discussing and planning small events that are 
 not yet ready to seek final approval.
 
 
-| Volume: | Moderate |
-|---------|----------|
-| Subscription address: |  [small-events-discuss-subscribe@apache.org](mailto:small-events-discuss-subscribe@apache.org)  |
-| Unsubscription address: |  [small-events-discuss-unsubscribe@apache.org](mailto:small-events-discuss-unsubscribe@apache.org)  |
-| Archives: | [Web archives](http://lists.apache.org/list.html?small-events-discuss@apache.org) |
-| Getting help with the list: |  [small-events-discuss-help@apache.org](mailto:small-events-discuss-help@apache.org)  |
+| Volume:                     | Moderate                                                                                          |
+| --------------------------- | ------------------------------------------------------------------------------------------------- |
+| Subscription address:       | [small-events-discuss-subscribe@apache.org](mailto:small-events-discuss-subscribe@apache.org)     |
+| Unsubscription address:     | [small-events-discuss-unsubscribe@apache.org](mailto:small-events-discuss-unsubscribe@apache.org) |
+| Archives:                   | [Web archives](http://lists.apache.org/list.html?small-events-discuss@apache.org)                 |
+| Getting help with the list: | [small-events-discuss-help@apache.org](mailto:small-events-discuss-help@apache.org)               |
 
 ## Community Mailing List  {#foundation-community}
 
@@ -225,10 +224,10 @@ are available.
 
 This replaces the old `community@a.o`mailing list, disabled in 2014.
 
-| Volume: | Moderate |
-|---------|----------|
-| Subscription address: |  [dev-subscribe@community.apache.org](mailto:dev-subscribe@community.apache.org)  |
-| Archives: | [Web archives](https://lists.apache.org/list.html?dev@community.apache.org) |
+| Volume:               | Moderate                                                                        |
+| --------------------- | ------------------------------------------------------------------------------- |
+| Subscription address: | [dev-subscribe@community.apache.org](mailto:dev-subscribe@community.apache.org) |
+| Archives:             | [Web archives](https://lists.apache.org/list.html?dev@community.apache.org)     |
 
 ## Foundation Infrastructure Mailing List  {#foundation-infrastructure}
 
@@ -246,10 +245,10 @@ our Apache Maven repository of other software releases. Participation in this li
 are available.
 
 
-| Volume: | Moderate |
-|---------|----------|
-| Subscription address: |  [repository-subscribe@apache.org](mailto:repository-subscribe@apache.org)  |
-| Archives: | [Web archives](https://lists.apache.org/list.html?repository@apache.org) |
+| Volume:               | Moderate                                                                  |
+| --------------------- | ------------------------------------------------------------------------- |
+| Subscription address: | [repository-subscribe@apache.org](mailto:repository-subscribe@apache.org) |
+| Archives:             | [Web archives](https://lists.apache.org/list.html?repository@apache.org)  |
 
 ## Foundation Legal Discussion Mailing List  {#foundation-legal}
 
@@ -265,8 +264,8 @@ without genuine knowledge of the subject.
 
 Volunteers willing to codify discussions into a FAQ are welcome.
 
-| Volume: | Moderate |
-|---------|----------|
-| Subscription address: |  [legal-discuss-subscribe@apache.org](mailto:legal-discuss-subscribe@apache.org)  |
-| Unsubscription address: |  [legal-discuss-unsubscribe@apache.org](mailto:legal-discuss-unsubscribe@apache.org)  |
-| Archives: | Raw gzipped [mbox files](/mail/legal-discuss/)<br />[Web archives](http://lists.apache.org/list.html?legal-discuss@apache.org) |
+| Volume:                 | Moderate                                                                                                                       |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| Subscription address:   | [legal-discuss-subscribe@apache.org](mailto:legal-discuss-subscribe@apache.org)                                                |
+| Unsubscription address: | [legal-discuss-unsubscribe@apache.org](mailto:legal-discuss-unsubscribe@apache.org)                                            |
+| Archives:               | Raw gzipped [mbox files](/mail/legal-discuss/)<br />[Web archives](http://lists.apache.org/list.html?legal-discuss@apache.org) |

--- a/content/foundation/news.md
+++ b/content/foundation/news.md
@@ -11,7 +11,7 @@ Keep informed about news from the Apache Software Foundation and its
 projects by subscribing to the [Apache
 Announcements](mailinglists.html#foundation-announce) mailing list. To see
 what has happened recently, please check the [archives of Apache
-Announcements](http://mail-archives.apache.org/mod_mbox/www-announce/) or
+Announcements](https://lists.apache.org/list.html?announce@apache.org) or
 you can visit [our foundation blog](https://blogs.apache.org/foundation/).
 
 See the [current listing of News and Announcements](/press/#news).

--- a/content/history/data/timeline.xml
+++ b/content/history/data/timeline.xml
@@ -9,7 +9,7 @@
 <event title="ACEU 2001 CANCELLED" start="07/17/2001" isDuration="false" icon="http://simile.mit.edu/timeline/api/images/dark-green-circle.png" image="ac-reg.png" color="#008000" caption="ACEU 2001 CANCELLED" >Due to financial/producer issues, the ACEU2001 conference was cancelled for Dublin.  CFPs were collected.</event>
 <event title="ACUS 2002 CFP" start="05/01/2002" end="05/31/2002" isDuration="true" image="ac-cfp.png" caption="ACUS 2002 CFP" >Begin date is approximate!</event>
 <event title="ACUS 2002 Registration" start="09/17/2002" isDuration="false" image="ac-reg.png" caption="ACUS 2002 Registration" >Early bird discounts featured.</event>
-<event title="ACUS 2002 Early Bird Ends" start="10/04/2002" isDuration="false" image="ac-reg.png" caption="ACUS 2002 Early Bird Ends" >Was extended by http://mail-archives.apache.org/mod_mbox/www-announce/200210.mbox/ajax/%3c3D9DE70C.B40AA76A@apache.org%3e</event>
+<event title="ACUS 2002 Early Bird Ends" start="10/04/2002" isDuration="false" image="ac-reg.png" caption="ACUS 2002 Early Bird Ends" >Was extended by https://lists.apache.org/thread/xsbqckbbdwckchszbly8j0ocf4t3vy98</event>
 <event title="ACUS 2003 Registration" start="09/15/2003" isDuration="false" image="ac-reg.png" caption="ACUS 2003 Registration" >Early bird was featured.</event>
 <event title="ACUS 2003 Hyper Early Bird Ends" start="09/30/2003" isDuration="false" image="ac-reg.png" caption="ACUS 2003 Hyper Early Bird Ends" >There were multiple levels of early bird pricing with various discounts.</event>
 <event title="ACUS 2004 Logo Contest" start="09/01/2004" end="09/15/2004" isDuration="true" image="ac-reg.png" caption="ACUS 2004 Logo Contest" >Logo contest held; winner gets discounted pass to the Fabulous Alexis Park Hotel!</event>

--- a/content/legal/3party.md
+++ b/content/legal/3party.md
@@ -1,5 +1,4 @@
 Title: Third-Party Licensing Policy - The Apache Software Foundation
-Atom: http://mail-archives.apache.org/mod_mbox/www-legal-discuss/?format=atom
 Notice: http://www.apache.org/licenses/LICENSE-2.0
 
 # Third-Party Licensing Policy #

--- a/content/legal/generative-tooling.md
+++ b/content/legal/generative-tooling.md
@@ -1,5 +1,4 @@
 Title: ASF Generative Tooling Guidance
-Atom: http://mail-archives.apache.org/mod_mbox/www-legal-discuss/?format=atom "ASF legal-discuss Mailing List"
 license: https://www.apache.org/licenses/LICENSE-2.0
 
 # {{title}}

--- a/content/legal/index.md
+++ b/content/legal/index.md
@@ -1,5 +1,4 @@
 Title: ASF Legal & Trademark | Apache Software Foundation
-Atom: http://mail-archives.apache.org/mod_mbox/www-legal-discuss/?format=atom
 Notice: http://www.apache.org/licenses/LICENSE-2.0
 
 # ASF Legal & Trademark
@@ -9,13 +8,13 @@ Notice: http://www.apache.org/licenses/LICENSE-2.0
 
 The following pages provide information for users of Apache Products (i.e. software products from the ASF).
 
-| Page | Description |
-| ---- | ----------- |
-| [Apache Licenses](/licenses/) | Details the Apache License 2.0 and other licences from the ASF |
-| [Records of Incorporation and Tax Status](/foundation/records/) | Our official records |
-| [Information on encryption within Apache products](/licenses/exports/)  | Export Control information |
-| [Trademark and Logo Usage Guidelines](/foundation/marks/)  | Our Trademark policy |
-| [DMCA Designated Agent page](/legal/dmca) | For DMCA-related issues |
+| Page                                                                   | Description                                                    |
+| ---------------------------------------------------------------------- | -------------------------------------------------------------- |
+| [Apache Licenses](/licenses/)                                          | Details the Apache License 2.0 and other licences from the ASF |
+| [Records of Incorporation and Tax Status](/foundation/records/)        | Our official records                                           |
+| [Information on encryption within Apache products](/licenses/exports/) | Export Control information                                     |
+| [Trademark and Logo Usage Guidelines](/foundation/marks/)              | Our Trademark policy                                           |
+| [DMCA Designated Agent page](/legal/dmca)                              | For DMCA-related issues                                        |
 
 We appreciate feedback on our licenses, agreements and processes (see [communications](#communications)). Sadly, we are unable to offer legal opinions or advice to the public. 
 
@@ -24,14 +23,14 @@ We appreciate feedback on our licenses, agreements and processes (see [communica
 
 The following pages provide information for Apache Software Foundation committers to assist in their work on Apache Products.  
 
-| Page | Description |
-| ---- | ----------- |
-| [ASF Release Policy](/legal/release-policy.html) | Apache Release Policy for Apache Products |
-| [Apache Software Foundation 3rd Party License Policy](/legal/resolved.html) | Information related to third-party license use in Apache Products |
-| [Source Header and Copyright Notice Policy](/legal/src-headers.html) | Instructions on the application of source headers to ASF source files |
-| [CLA FAQ](/foundation/license-faq.html) | Questions related to signing our [Contributor License Agreements](/licenses/#clas) |
-| [Handling Cryptography within an ASF Release](/dev/crypto.html) | Cryptography Policy |
-| [Generative Tooling Guidance](/legal/generative-tooling.html) | Guidance relating to the use of Generative Tooling |
+| Page                                                                        | Description                                                                        |
+| --------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
+| [ASF Release Policy](/legal/release-policy.html)                            | Apache Release Policy for Apache Products                                          |
+| [Apache Software Foundation 3rd Party License Policy](/legal/resolved.html) | Information related to third-party license use in Apache Products                  |
+| [Source Header and Copyright Notice Policy](/legal/src-headers.html)        | Instructions on the application of source headers to ASF source files              |
+| [CLA FAQ](/foundation/license-faq.html)                                     | Questions related to signing our [Contributor License Agreements](/licenses/#clas) |
+| [Handling Cryptography within an ASF Release](/dev/crypto.html)             | Cryptography Policy                                                                |
+| [Generative Tooling Guidance](/legal/generative-tooling.html)               | Guidance relating to the use of Generative Tooling                                 |
 
 
 ### The Legal Affairs Committee  {#communications}
@@ -44,8 +43,8 @@ Questions for the Legal Affairs Committee should be raised on
 
 Most discussions are held on the public 
 [legal-discuss@](/foundation/mailinglists.html#foundation-legal)
-mailing list. See the [legal-discuss@
-archives](http://mail-archives.apache.org/mod_mbox/www-legal-discuss/) 
+mailing list. See the
+[legal-discuss@ archives](https://lists.apache.org/list.html?legal-discuss@apache.org) 
 for previous discussions.
 
 The Legal Affairs Committee (including VP of Legal Affairs) is staffed exclusively by volunteers 
@@ -57,8 +56,8 @@ much longer. For truly urgent matters always make sure to contact vp-legal@apach
 
 ### Historical and background documents  {#background-links}
 
-| Page | Description |
-| ---- | ----------- |
-| [Legal Affairs reports](https://whimsy.apache.org/board/minutes/Legal_Affairs.html) | The board reports to date |
+| Page                                                                                                                         | Description                                                                                                                      |
+| ---------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| [Legal Affairs reports](https://whimsy.apache.org/board/minutes/Legal_Affairs.html)                                          | The board reports to date                                                                                                        |
 | [Draft Third-Party Licensing Policy](https://svn.apache.org/repos/asf/infrastructure/site/trunk/archive/legal/3party.mdtext) | Cliff Schmidt's original drafting. While never enacted, this draft provided the foundation from which the current policy evolved |
-| [Ramblings of an ASF VP of Legal Affairs](/legal/ramblings.html) | Sam Ruby's subsequent thoughts |
+| [Ramblings of an ASF VP of Legal Affairs](/legal/ramblings.html)                                                             | Sam Ruby's subsequent thoughts                                                                                                   |

--- a/content/legal/ramblings.md
+++ b/content/legal/ramblings.md
@@ -1,5 +1,4 @@
 Title: Ramblings of an ASF VP of Legal Affairs
-Atom: http://mail-archives.apache.org/mod_mbox/www-legal-discuss/?format=atom
 Notice: http://www.apache.org/licenses/LICENSE-2.0
 
 # {{title}}
@@ -102,9 +101,8 @@ emerge.
 
 And just when you think you can get a handle on this, people invent new
 licenses, new
-[clauses](http://mail-archives.apache.org/mod_mbox/www-legal-discuss/200803.mbox/%3c47DEB046.10004@dubioso.net%3e)
-, and new
-[exclusions](http://mail-archives.apache.org/mod_mbox/www-legal-discuss/200802.mbox/%3cE1A2049F-5D7B-44F7-A1E3-B9645BC52348@yahoo.com%3e).
+[clauses](https://lists.apache.org/thread/b0806ypoqlm9ytjkvdbm90blnt5skz8y)
+, and new [exclusions](https://lists.apache.org/thread/stw8nh1pg1gl97s04jcbdo5ctf4t4n6y).
 And new [uses](https://lists.apache.org/thread/wk1dskb4h2dzo5t71wyz5lgf0pc23hx4).
 
 ### Approximation 3  {#head-cc4186e2c34505e5dddc5c9b5e40a655cd699e5c}

--- a/content/legal/resolved.md
+++ b/content/legal/resolved.md
@@ -1,5 +1,4 @@
 Title: ASF 3rd Party License Policy
-Atom: http://mail-archives.apache.org/mod_mbox/www-legal-discuss/?format=atom "ASF legal-discuss Mailing List"
 license: https://www.apache.org/licenses/LICENSE-2.0
 
 # {{title}}

--- a/content/legal/src-headers.md
+++ b/content/legal/src-headers.md
@@ -1,6 +1,4 @@
 Title: ASF Source Header and Copyright Notice Policy
-Atom: http://mail-archives.apache.org/mod_mbox/www-legal-discuss/?format=atom "ASF legal-discuss Mailing List"
-Comment: atom header to get a link like: "<link rel="alternate" title="ASF legal-discuss Mailing List" type="application/atom+xml" href="http://mail-archives.apache.org/mod_mbox/www-legal-discuss/?format=atom" />" in the generated html header (in the body it would be trivial)
 license: https://www.apache.org/licenses/LICENSE-2.0
 
 # {{title}}


### PR DESCRIPTION
cc @bproffitt @ShaneCurcuru @sebbASF 

1. Clarify archive sites not being comprehensive or controlled by the ASF.
2. Manually fold mail-archives.apache.org to its redirection lists.a.o
3. Remove some Atom header that I found they are not in used anymore.