### PR TITLE
home.a.o => people.a.o

### DIFF
--- a/content/board/services.md
+++ b/content/board/services.md
@@ -34,7 +34,7 @@ that PMCs can use to self-evaluate.  You can [contact ComDev](https://community.
 
 Example services include: [Board Report Helper](https://reporter.apache.org/), 
 [Project Community Health Tips](https://reporter.apache.org/chi.py), 
-[Apache Committer 'Phone Book' listing](https://home.apache.org/), 
+[Apache Committer 'Phone Book' listing](https://people.apache.org/), 
 [Mentoring ideas](https://community.apache.org/mentoringprogramme.html), 
 and [Google Summer of Code assistance](https://community.apache.org/gsoc.html).
 

--- a/content/dev/infrastructure.md
+++ b/content/dev/infrastructure.md
@@ -37,7 +37,7 @@ Infra uses many Apache software applications, including:
 - [Directory Studio](http://directory.apache.org/studio/)
 
 Infra also uses and maintains a selection of [in-house projects](https://svn.apache.org/repos/infra/infrastructure/trunk/projects/),
-including the [committers index](http://home.apache.org/committer-index.html) and the [committers' URL Shortener](http://s.apache.org/).
+including the [committers index](http://people.apache.org/committer-index.html) and the [committers' URL Shortener](http://s.apache.org/).
 
 
 ## Useful links  {#infra}

--- a/content/dev/pmc.md
+++ b/content/dev/pmc.md
@@ -453,7 +453,7 @@ a board member. Your PMC needs to work with the new committer to ensure
 that their CLA is received and recorded properly, so you need to monitor
 the file `iclas.txt` in the `foundation/officers` repository. Only ASF
 members and officers (PMC chairs) have access. The Apache Phone Book
-has an [Unlisted CLAs](https://home.apache.org/unlistedclas.html) page
+has an [Unlisted CLAs](https://people.apache.org/unlistedclas.html) page
 which is generated daily from the `iclas.txt` file, and recently received CLAs
 appear there.
 
@@ -641,8 +641,8 @@ There are two main ways to check the membership of PMCs and LDAP groups:
 
   - Committers can view, and PMC chairs can update, PMC rosters using 
 [Whimsy](https://whimsy.apache.org/roster/committee/).
-  - Anyone may view Apache Phonebook pages at [https://home.apache.org/phonebook.html](https://home.apache.org/phonebook.html).
-From there you can link to a specific PMC like this: [home.apache.org/phonebook.html?pmc=gump](https://home.apache.org/phonebook.html?pmc=gump)
+  - Anyone may view Apache Phonebook pages at [https://people.apache.org/phonebook.html](https://people.apache.org/phonebook.html).
+From there you can link to a specific PMC like this: [people.apache.org/phonebook.html?pmc=gump](https://people.apache.org/phonebook.html?pmc=gump)
 
 Please allow time for any changes to LDAP and committee-info.txt to propagate to the Phonebook app.
 

--- a/content/foundation/.htaccess
+++ b/content/foundation/.htaccess
@@ -1,7 +1,7 @@
 RedirectMatch /foundation/ASF_Contributor_License_\d(_form)?\.pdf$ /licenses/#clas
 RedirectMatch permanent /foundation/roles.html(.*)$ /foundation/how-it-works.html$1
-Redirect /foundation/committers.html https://home.apache.org/committer-index.html
-Redirect /foundation/projects.html https://home.apache.org/committers-by-project.html
+Redirect /foundation/committers.html https://people.apache.org/committer-index.html
+Redirect /foundation/projects.html https://people.apache.org/committers-by-project.html
 Redirect /foundation/licence-FAQ.html /foundation/license-faq.html
 Redirect /foundation/contributing-v5.html /foundation/contributing.html
 Redirect /foundation/policies/privacy.html https://privacy.apache.org/policies/privacy-policy-public.html

--- a/content/foundation/how-it-works/index.md
+++ b/content/foundation/how-it-works/index.md
@@ -293,7 +293,7 @@ nature of the various communities.
 
 ### Documentation
 
-Each project is responsible for its own [project website](https://home.apache.org/committers-by-project.html).
+Each project is responsible for its own [project website](https://people.apache.org/committers-by-project.html).
 Further information to assist committers, developers, and PMCs is available
 at [ASF Infrastructure](/dev/).
 


### PR DESCRIPTION
home is an alias for people, but is deprecated as a name. This is because it is not longer avaliable as a home for user files