### PR TITLE
Update leadership.ezmd after committee-info changes

### DIFF
--- a/content/foundation/leadership.ezmd
+++ b/content/foundation/leadership.ezmd
@@ -54,13 +54,13 @@ A <a href="/history/directors.html">timeline</a> of who has served on the ASF Bo
 | V.P., [[]Conferences](https://events.apache.org/) |  [{ ci[concom][chair] }] |
 | V.P., [[]Data Privacy](https://privacy.apache.org/) |  [{ ci[dataprivacy][chair] }] |
 | V.P., [[]Diversity and Inclusion](http://diversity.apache.org/) |  [{ ci[diversity][chair] }] |
-| V.P., ECMA Relations |  [{ ci[ecmarelations][roster] }] |
+| V.P., ECMA Relations |  [{ ci[ecmarelations][chair] }] |
 | V.P., [[]Fundraising](/foundation/sponsorship.html) |  [{ ci[fundraising][chair] }] |
-| V.P., Sponsor Relations |  [{ ci[sponsorrelations][roster] }] |
-| V.P., [[]Infrastructure](/dev/infrastructure.html) |  [{ ci[infrastructure][roster] }] |
-| [[]Infrastructure Administrator](/dev/infrastructure.html) |  [{ ci[infrastructureadministrator][roster] }] |
+| V.P., Sponsor Relations |  [{ ci[sponsorrelations][chair] }] |
+| V.P., [[]Infrastructure](/dev/infrastructure.html) |  [{ ci[infrastructure][chair] }] |
+| [[]Infrastructure Administrator](/dev/infrastructure.html) |  [{ ci[infrastructureadministrator][chair] }] |
 | V.P., [[]Marketing and Publicity](/press/) |  [{ ci[marketingandpublicity][chair] }] |
-| V.P., Tooling |  [{ ci[tooling][roster] }] |
+| V.P., Tooling |  [{ ci[tooling][chair] }] |
 | V.P., [[]Travel Assistance](https://tac.apache.org/) |  [{ ci[tac][chair] }] |
 | V.P., Public Affairs |  [{ ci[publicaffairs][chair] }] |
 


### PR DESCRIPTION
Fixes the leadership page ezt to handle moving of officers. There is an anomaly in the `committee-info.json` that is produced and several officers were moved from `roster` to `chair`