### PR TITLE
Convert to ezmd so can reference variables for roles

### DIFF
--- a/content/foundation/marks/index.ezmd
+++ b/content/foundation/marks/index.ezmd
@@ -13,33 +13,33 @@ the **names of all ASF projects are trademarks of the ASF**.
 The following information helps ensure our marks and logos are used in
 approved ways by other parties, so we can legally protect our project brands 
 and encourage third parties to use ASF software and our brands in approved 
-ways. [Contact us][contact] with any questions 
+ways. [[]Contact us][[]contact] with any questions 
 about this policy or about ASF trademarks, and **read our 
-[list of trademark resources][resources]**.
+[[]list of trademark resources][[]resources]**.
 
 ## Trademark Policy Quick Links
 
--  [Rationale](#rationale) 
+-  [[]Rationale](#rationale) 
 
--  [Description of Key Trademark Principles](#principles) 
+-  [[]Description of Key Trademark Principles](#principles) 
 
--  [Specific ASF Trademark Policies](#guidelines) 
+-  [[]Specific ASF Trademark Policies](#guidelines) 
 
-   -  [Policy for Software Products](#products)
+   -  [[]Policy for Software Products](#products)
 
-   -  [Policy for Published Books or Articles](#books)
+   -  [[]Policy for Published Books or Articles](#books)
  
-   -  [Policy for Domain Names](#domains) 
+   -  [[]Policy for Domain Names](#domains) 
 
-   -  [Policy for Events](#events) 
+   -  [[]Policy for Events](#events) 
 
--  [List of ASF Trademarks](list) 
+-  [[]List of ASF Trademarks](list) 
 
--  [Frequently Asked Questions](faq) 
+-  [[]Frequently Asked Questions](faq) 
 
--  [Who We Are](#whoweare) 
+-  [[]Who We Are](#whoweare) 
 
--  [More ASF Trademark Resources](resources)
+-  [[]More ASF Trademark Resources](resources)
 
 ## Rationale  {#rationale}
 
@@ -60,13 +60,13 @@ Apache Software Foundation trademarks must not be used to disparage the ASF, our
 projects, members, sponsors, or communities, nor be used in any way to imply
 ownership, endorsement, or sponsorship of any ASF-related project or
 initiative of any kind.  We are a vendor-neutral organization, and an important part of 
-our brand is that [ASF projects are governed independently][independent].
+our brand is that [[]ASF projects are governed independently][[]independent].
 
 ## Description of Key Trademark Principles  {#principles}
 
 This section is not intended to summarize the complex law of trademarks. However,
 it may help you understand some key principles.  More 
-information is on our [trademark resources listing][resources].
+information is on our [[]trademark resources listing][[]resources].
 
 **What is a trademark?**
 
@@ -94,8 +94,8 @@ use.
 Within the ASF, during our product release activity and on ASF websites, we
 make sure that our trademarks are marked with a (TM) or (R) symbol or
 shown with trademark notices where appropriate so that everyone can
-recognize them as ASF trademarks. We provide a [list of ASF
-trademarks](list), and a [detailed guide on how to refer to ASF brands][brandguide].
+recognize them as ASF trademarks. We provide a [[]list of ASF
+trademarks](list), and a [[]detailed guide on how to refer to ASF brands][[]brandguide].
 
 **What is nominative use?**
 
@@ -135,7 +135,7 @@ tarnishing their mark under the state and/or federal dilution laws.
 To avoid infringing ASF's marks, you should verify that your use of our
 marks is nominative and that you are not likely to confuse software
 consumers that your software is the same as ASF's software or is endorsed
-by ASF. This policy is already summarized in section 6 of the [Apache
+by ASF. This policy is already summarized in section 6 of the [[]Apache
 License](/licenses/) , and so it is a condition for your use of ASF
 software:
 
@@ -150,7 +150,7 @@ The following Specific Policies apply to the "Apache" word trademark and
 the "ASF feather" graphic trademark, as well as the trademarks and
 graphic logos for all "Apache *ProjectName*" and "*ProjectName*" software produced by each
 of the ASF's projects.  You may refer to our 
-[list of ASF marks](/foundation/marks/list/). 
+[[]list of ASF marks](/foundation/marks/list/). 
 
 Examples of permitted nominative fair use:
 
@@ -169,12 +169,12 @@ or "Apache *ProjectName*" or the *ProjectName* graphic logo trademarks.
 
 - "This &lt;here&gt; is the graphic logo for Apache *ProjectName* software."
 
-- The ASF prefers you use the [full Apache *ProjectName* name][brandguide] for all our projects.
+- The ASF prefers you use the [[]full Apache *ProjectName* name][[]brandguide] for all our projects.
 
 ### Using ASF Trademarks in software product branding  {#products}
 
-In general you may [**not** use ASF trademarks in any software product branding][products]. 
-However in very specific situations you may use the [Powered By naming form][poweredby] for software products. 
+In general you may [[]**not** use ASF trademarks in any software product branding][[]products]. 
+However in very specific situations you may use the [[]Powered By naming form][[]poweredby] for software products. 
 
 ### Using ASF Trademarks in published books and articles  {#books}
 
@@ -189,21 +189,21 @@ title if it fits, and we request that you clearly identify that "Apache",
 wherever you normally acknowledge important trademarks in your book or
 article.
 
-For more details, please see our [FAQ about ASF marks in publishing](faq/#booktitle).
+For more details, please see our [[]FAQ about ASF marks in publishing](faq/#booktitle).
 
 **Using the ASF feather logo to identify the ASF and link to
-[www.apache.org](/) :**
+[[]www.apache.org](/) :**
 
 The ASF feather logo is a special trademark for the members of the Apache
 Software Foundation and we intend to prevent its use in association with
 other companies' software or related services.
 
 You needn't ask us for permission to use the ASF feather logo (the
-version published by us [here](/foundation/press/kit/) ) on your own
-website solely as a hyperlink to [www.apache.org](/) or to an appropriate ASF project, or in other materials, 
+version published by us [[]here](/foundation/press/kit/) ) on your own
+website solely as a hyperlink to [[]www.apache.org](/) or to an appropriate ASF project, or in other materials, 
 such as presentations and slides, solely as a means to refer to the ASF itself.
 
-The VP, Brand Management or a member of the Brand Management Committee  must [approve in writing][contactother] all other uses of the ASF feather logo.
+The VP, Brand Management or a member of the Brand Management Committee  must [[]approve in writing][[]contactother] all other uses of the ASF feather logo.
 
 **Using the Apache Foo or similar project graphic logos:**
 
@@ -217,9 +217,9 @@ software and their project websites.
 You needn't ask us for permission to use the ASF's graphics logos (the
 versions published on individual project's websites) on your own website
 solely as a hyperlink to the specific ASF project website or to
-[www.apache.org](/). The VP, Brand Management, a
+[[]www.apache.org](/). The VP, Brand Management, a
 member of the Brand Management Committee, or the relevant Apache 
-project's VP  must [approve in writing][contact] all other uses of Apache Foo (and similar) graphic
+project's VP  must [[]approve in writing][[]contact] all other uses of Apache Foo (and similar) graphic
 logos.
 
 Unlike ASF's word trademarks (such as "Apache" and "Foo"), our graphic
@@ -230,11 +230,11 @@ apply any "confusingly similar" derivative logo to software if a relevant
 consumer would likely be confused by your use of that derivative logo.
 
 If you have any questions or concerns about the use of or changes to any
-ASF graphic trademark, [contact us][contact]
+ASF graphic trademark, [[]contact us][[]contact]
 
 **Using ASF trademarks on merchandise:**
 
-You must obtain prior [written approval][contactswag] from the VP, Brand Management
+You must obtain prior [[]written approval][[]contactswag] from the VP, Brand Management
 or designee to apply the "Apache", "Apache Foo" or "Foo" trademarks or their graphic
 logos to any merchandise that is intended to be associated in people's
 minds with Apache Foo software or any ASF software.
@@ -267,7 +267,7 @@ realize that the use of ASF trademarks in your domain names is generally not
 "nominative fair use."
 
 For more details and to request approvals, please see our 
-[Domain Name Branding Policy](/foundation/marks/domains.html). 
+[[]Domain Name Branding Policy](/foundation/marks/domains.html). 
 In particular, using ASF product names as second level domain names (*example*.com) is not allowed.
 
 
@@ -286,18 +286,18 @@ conferences or events must be approved in writing from the VP,
 Brand Management or designee.
 
 For more details and to request approvals, please see our 
-[Event Branding Policy](/foundation/marks/events.html). 
+[[]Event Branding Policy](/foundation/marks/events.html). 
 Please request approvals well in advance to avoid ApacheCon blackout dates.
 
 ## Who We Are  {#whoweare}
 
-The [VP, Brand Management](/foundation/) and associated Brand Management
+The [[]VP, Brand Management](/foundation/) and associated Brand Management
 Committee is the formal body within the ASF responsible for setting policy
 and answering questions about the use of our logos and trademarks, along
 with other responsibilities. The Committee is made up of elected members of
 the ASF who have shown merit in the branding and trademarks areas. The
-current VP, Brand Management is Mark Thomas, as appointed by the
-President to serve in this position.  See a [list of committee members and how to contact us][contact].
+current VP, Brand Management is [{ ci[brand][chair] }], as appointed by the
+President to serve in this position.  See a [[]list of committee members and how to contact us][[]contact].
 
 ## Important Note  {#notes}
 
@@ -315,14 +315,14 @@ This is version 1.2 of this ASF policy document, published in March 2021. We wil
 **v1.2** Update to use ASF to refer to the Apache Software Foundation
 
 
-[contact]: /foundation/marks/contact
-[contactevents]: /foundation/marks/contact#events
-[contactdomains]: /foundation/marks/contact#domains
-[contactproducts]: /foundation/marks/contact#products
-[contactswag]: /foundation/marks/contact#swag
-[contactother]: /foundation/marks/contact#other
-[independent]: //community.apache.org/projectIndependence
-[resources]: /foundation/marks/resources
-[brandguide]: /foundation/marks/guide
-[products]: /foundation/marks/faq/#products
-[poweredby]: /foundation/marks/faq/#poweredby
+[[]contact]: /foundation/marks/contact
+[[]contactevents]: /foundation/marks/contact#events
+[[]contactdomains]: /foundation/marks/contact#domains
+[[]contactproducts]: /foundation/marks/contact#products
+[[]contactswag]: /foundation/marks/contact#swag
+[[]contactother]: /foundation/marks/contact#other
+[[]independent]: //community.apache.org/projectIndependence
+[[]resources]: /foundation/marks/resources
+[[]brandguide]: /foundation/marks/guide
+[[]products]: /foundation/marks/faq/#products
+[[]poweredby]: /foundation/marks/faq/#poweredby

--- a/content/foundation/policies/conduct.ezmd
+++ b/content/foundation/policies/conduct.ezmd
@@ -5,7 +5,7 @@ license: https://www.apache.org/licenses/LICENSE-2.0
 
 ## Introduction
 
-This code of conduct applies to all spaces the Apache Software Foundation manages, including IRC, public and private mailing lists, issue trackers, wikis, blogs, Twitter, and any other communication channels our communities use. A code of conduct which is specific to in-person events (ie., conferences) is in the ASF [anti-harassment policy](anti-harassment.html).
+This code of conduct applies to all spaces the Apache Software Foundation manages, including IRC, public and private mailing lists, issue trackers, wikis, blogs, Twitter, and any other communication channels our communities use. A code of conduct which is specific to in-person events (ie., conferences) is in the ASF [[]anti-harassment policy](anti-harassment.html).
 
 We expect everyone who participates in the Apache community formally or informally, or claims any affiliation with the Foundation, in any Foundation-related
 activities and especially when representing the ASF in any role to honor this code of conduct.
@@ -62,8 +62,8 @@ While all participants should adhere to this code of conduct, we recognize that 
 
 Assume good faith; it is more likely that participants are unaware of their bad behaviour than that they intentionally try to degrade the quality of the discussion. Should there be difficulties in dealing with the situation, you may report your compliance issues in confidence to:
  
- * [President](https://whimsy.apache.org/foundation/orgchart) of The Apache Software Foundation: Ruth Suehle (president AT apache DOT org)
- * [Executive Vice President](https://whimsy.apache.org/foundation/orgchart) of The Apache Software Foundation: Jeff Jirsa (jjirsa AT apache DOT org)
+ * [[]President](https://whimsy.apache.org/foundation/orgchart) of The Apache Software Foundation: [{ ci[president][roster] }] (president AT apache DOT org)
+ * [[]Executive Vice President](https://whimsy.apache.org/foundation/orgchart) of The Apache Software Foundation: [{ ci[execvp][roster] }] ([{ ci[execvp][availid] }] AT apache DOT org)
 
 or one of our volunteers:
 
@@ -81,12 +81,12 @@ This Code defines __empathy__ as "a vicarious participation in the emotions, ide
 This statement draws on the following for content and inspiration:
 
 
-  * [CouchDB Project Code of conduct](http://couchdb.apache.org/conduct.html)
-  * [Fedora Project Code of Conduct](http://fedoraproject.org/code-of-conduct)
-  * [Speak Up! Code of Conduct](http://speakup.io/coc.html)
-  * [Django Code of Conduct](https://www.djangoproject.com/conduct/)
-  * [Debian Code of Conduct](http://www.debian.org/vote/2014/vote_002)
-  * [Twitter Open Source Code of Conduct](https://github.com/twitter/code-of-conduct/blob/master/code-of-conduct.md)
-  * [Mozilla Code of Conduct/Draft](https://wiki.mozilla.org/Code_of_Conduct/Draft#Conflicts_of_Interest)
-  * [Python Diversity Appendix](https://www.python.org/community/diversity/)
-  * [Python Mentors Home Page](http://pythonmentors.com/)
+  * [[]CouchDB Project Code of conduct](http://couchdb.apache.org/conduct.html)
+  * [[]Fedora Project Code of Conduct](http://fedoraproject.org/code-of-conduct)
+  * [[]Speak Up! Code of Conduct](http://speakup.io/coc.html)
+  * [[]Django Code of Conduct](https://www.djangoproject.com/conduct/)
+  * [[]Debian Code of Conduct](http://www.debian.org/vote/2014/vote_002)
+  * [[]Twitter Open Source Code of Conduct](https://github.com/twitter/code-of-conduct/blob/master/code-of-conduct.md)
+  * [[]Mozilla Code of Conduct/Draft](https://wiki.mozilla.org/Code_of_Conduct/Draft#Conflicts_of_Interest)
+  * [[]Python Diversity Appendix](https://www.python.org/community/diversity/)
+  * [[]Python Mentors Home Page](http://pythonmentors.com/)


### PR DESCRIPTION
Replaced current names of president and vp with references to variables, so no need to update the page on every change

See https://www-sebb-usevars.staged.apache.org/foundation/policies/conduct#reporting-guidelines