### PR TITLE
Fix pirk URL

### DIFF
--- a/data/eccn/eccnmatrix.yaml
+++ b/data/eccn/eccnmatrix.yaml
@@ -1028,7 +1028,7 @@ eccnmatrix:
           - version: 0.1.0-incubating and later
             eccn: 5D002
             source:
-              - href: 'https://dist.apache.org/repos/dist/dev/incubator/pirk/'
+              - href: 'https://archive.apache.org/dist/incubator/pirk/'
                 manufacturer: ASF
                 why: Includes cryptographic software implementation
       - name: Apache Pulsar


### PR DESCRIPTION
URLs referring to the host dist.apache.org should not be used for source references they are not permanent and not intended for external use