### PR TITLE
Replace fixed counts with asfdata variables

### DIFF
--- a/asfdata.yaml
+++ b/asfdata.yaml
@@ -39,6 +39,9 @@ ci:
     where: pmc
     # sort by project name
     alpha: display_name
+  pmc_count_rounded:
+    path: pmc_count
+    truncate: 10
   featured_projs:
     # used on /
     description: 'Featured Projects'
@@ -58,7 +61,9 @@ ci:
 
 # used on index.ezmd
 pods:
-  # load, transform, and create data sequences from podling info 
+  # load, transform, and create data sequences from podling info
+  # using data from projects.a.o because that only contains active podlings
+  # and the asfdata plugin does not yet support filtering by value other than True
   url: https://projects.apache.org/json/foundation/podlings.json
   podlings:
     description: 'Current Podlings'
@@ -108,7 +113,22 @@ pg:
   # rounded down, so can be used as nnn+
   asf_committers_rounded:
     path: roster_counts.committers
+    truncate: 100
+
+# used for index.ezmd and foundation/how-it-works/index.md
+mi:
+  url: https://whimsy.apache.org/public/member-info.json
+  asf_active_members_rounded:
+    path: member_count
     truncate: 10
+
+# used for index.ezmd
+
+# Not sure how this are derived
+software_releases_rounded: 1300
+
+# how does this relate to PMC count? (pmc_count_rounded)
+open_source_projects_rounded: 290
 
 # Can also define values as follows:
 # anumber: 100

--- a/content/dev/project-requirements.md
+++ b/content/dev/project-requirements.md
@@ -5,7 +5,7 @@ license: https://www.apache.org/licenses/LICENSE-2.0
 
 **What is an Apache project?**
 
-The ASF is home to a wide range of over 350 software project communities, each working with their own collaborative community style to create the freely-available software products that Apache is known for. There are many different references to "The Apache Way" and project policies at the ASF, but it is not always clear which policies are required, which are best practices, and which are merely suggestions.
+The ASF is home to a wide range of over {{pmc_count_rounded}} software project communities, each working with their own collaborative community style to create the freely-available software products that Apache is known for. There are many different references to "The Apache Way" and project policies at the ASF, but it is not always clear which policies are required, which are best practices, and which are merely suggestions.
 
 This document provides a simple list of the ASF's expectations of any Apache project, with pointers to the detailed policies or best practices. **"Apache project" specifically means a top level project at the ASF**. Incubator podlings must meet these requirements before graduation. Projects not hosted at the ASF - even if they are using the Apache license - are not strictly "Apache projects".
 

--- a/content/foundation/marks/guide.md
+++ b/content/foundation/marks/guide.md
@@ -3,7 +3,7 @@ license: https://www.apache.org/licenses/LICENSE-2.0
 
 
 
-The Apache&reg; brand is shared amongst all 200+ Apache Software Foundation (ASF) project
+The Apache&reg; brand is shared amongst all {{pmc_count_rounded}}+ Apache Software Foundation (ASF) project
 communities and is an important part of our mission of providing
 software for the public good.  This identity usage guide provides
 examples for how to refer to Apache&reg; software projects and products.

--- a/content/foundation/marks/templates/product-misuse.md
+++ b/content/foundation/marks/templates/product-misuse.md
@@ -39,7 +39,7 @@ Once the other party claims they are in compliance with our policy and have made
 
 Dear *THEIRNAME*:
 
-The Apache Software Foundation (“ASF”) is a US 501(c)(3) non-profit public charity that provides organizational, legal, and financial support for nearly 200 independently led open source software projects under the Apache® brand. 
+The Apache Software Foundation (“ASF”) is a US 501(c)(3) non-profit public charity that provides organizational, legal, and financial support for over {{pmc_count_rounded}} independently led open source software projects under the Apache® brand. 
 
 One of the ASF’s important activities is uniting our communities by using Apache trademarks and logos to identify projects and software developed by our volunteer communities.  Unfortunately, an increasing number of companies are claiming improper connections with Apache software projects and the software products we produce, often in a way that harms the vendor neutral and independent governance that Apache projects are widely known for.
 

--- a/content/foundation/press/index.md
+++ b/content/foundation/press/index.md
@@ -3,7 +3,7 @@ license: https://www.apache.org/licenses/LICENSE-2.0
 
 # ASF Marketing & Publicity #
 
-The Apache Software Foundation (ASF) Marketing & Publicity team oversees the ASF's public image, handles day-to-day media and analyst relations, and supports the Foundation by counseling 350+ Apache projects and their communities in the areas of messaging, outreach, and engagement.
+The Apache Software Foundation (ASF) Marketing & Publicity team oversees the ASF's public image, handles day-to-day media and analyst relations, and supports the Foundation by counseling {{open_source_projects_rounded}}+ Apache projects and their communities in the areas of messaging, outreach, and engagement.
 
 
 ## Helpful Resources  { #resources }

--- a/content/free/index.md
+++ b/content/free/index.md
@@ -13,7 +13,7 @@ Apache projects will never charge a fee for downloading or using their software.
 
 ## Is Apache software really free to download?
 
-Yes.  Over 300 Apache projects and podlings provide software products that may be 
+Yes.  Over {{pmc_count_rounded}} Apache projects and {{podlings_size}} podlings provide software products that may be 
 downloaded and used at no cost, including everything from the world-famous 
 [Apache HTTP Server][1], to [Apache Hadoop][2], to [Apache Lucene][3], 
 to [Apache OpenOffice][4], and many, many more.

--- a/content/index.ezmd
+++ b/content/index.ezmd
@@ -75,16 +75,16 @@ bodytag: id="home"
         <h2 class="text-white mt-0">Our Impact</h2>
         <div class="stat-boxes flex flex-center mt-large">
             <div class="stat-box">
-                <a href="https://projects.apache.org/">290+ </br> <span>Open Source Projects</span></a>
+                <a href="https://projects.apache.org/">[open_source_projects_rounded]+ </br> <span>Open Source Projects</span></a>
             </div>
             <div class="stat-box">
-                <a href="https://projects.apache.org/releases">1300+ </br> <span>Software Releases</span></a>
+                <a href="https://projects.apache.org/releases">[software_releases_rounded]+ </br> <span>Software Releases</span></a>
             </div>
             <div class="stat-box">
-                <a href="https://github.com/orgs/apache/people">9900+ </br> <span>Committers</span></a>
+                <a href="https://github.com/orgs/apache/people">[asf_committers_rounded]+ </br> <span>Committers</span></a>
             </div>
             <div class="stat-box">
-                <a href="/foundation/members">1100+ </br> <span>Members</span></a>
+                <a href="/foundation/members">[asf_active_members_rounded]+ </br> <span>Members</span></a>
             </div>
         </div>
     </div>

--- a/content/press/boilerplate/index.md
+++ b/content/press/boilerplate/index.md
@@ -24,7 +24,7 @@ reason to use the short form.
 > Established in 1999, the all-volunteer Foundation oversees more than sixty-five 
 > leading Open Source projects, including Apache HTTP Server -- the world's most 
 > popular Web server software. Through The ASF's meritocratic process known as 
-> "The Apache Way", nearly 300 individual Members and 2,000 Committers successfully 
+> "The Apache Way", over {{asf_members_rounded}} individual Members and {{asf_committers_rounded}} Committers successfully 
 > collaborate to develop freely available enterprise-grade software, benefiting 
 > millions of users worldwide: thousands of software solutions are distributed 
 > under the Apache License; and the community actively participates in ASF mailing 
@@ -53,7 +53,7 @@ and always send it to the apache.org home page.
 > **About The Apache Software Foundation (ASF)**
 > 
 > Established in 1999, The Apache Software Foundation provides organizational, 
-> legal, and financial support for more than 100 freely-available, 
+> legal, and financial support for more than {{pmc_count_rounded}} freely-available, 
 > collaboratively-developed Open Source projects. The pragmatic Apache License 
 > enables individual and commercial users to easily deploy Apache software; 
 > the Foundation's intellectual property framework limits the legal exposure 

--- a/content/press/media.md
+++ b/content/press/media.md
@@ -19,7 +19,7 @@ world's most popular Web server software since its creation in 1994.
 Evolving from the original eight developers (collectively known as "the
 Apache Group") who contributed code enhancements to the NCSA daemon Web
 server, The ASF today is a fully-distributed, non-profit organization
-comprising nearly 300 individual Members and over 2,000 Committers
+comprising over {{asf_members_rounded}} individual Members and {{asf_committers_rounded}} Committers
 across six continents.
 
 The ASF's successful


### PR DESCRIPTION
Fixed counts have been replaced with variable derived from asfdata.yaml in the following pages:

https://www-sebb-counts.staged.apache.org/
https://www-sebb-counts.staged.apache.org/dev/project-requirements 
https://www-sebb-counts.staged.apache.org/free 
https://www-sebb-counts.staged.apache.org/press/boilerplate
 https://www-sebb-counts.staged.apache.org/press/media

This ensures that the counts on different pages don't get out of sync, and avoids the need for regular page updates.