### PR TITLE
Move event list to a YAML file

### DIFF
--- a/asfdata.yaml
+++ b/asfdata.yaml
@@ -139,6 +139,11 @@ software_releases_rounded: 1300
 # how does this relate to PMC count? (pmc_count_rounded)
 open_source_projects_rounded: 290
 
+events:
+  file: data/events.yaml
+  events:
+    path: events
+
 # Can also define values as follows:
 # anumber: 100
 # astring: 'hundred'

--- a/content/index.ezmd
+++ b/content/index.ezmd
@@ -163,88 +163,36 @@ bodytag: id="home"
         <h2>Upcoming Events</h2>
         <div class="slideshow-container">
 	      	<!-- Full-width slides/quotes -->
-            <!-- Remember to adjust the number of dot-container entries below to agree with the slide count -->
-		    <div class="mySlides event-slide text-left">
-                <div class="flex">
-                    <div class="flex-1 event-info event-image">
-                        <div class="event-image-wrap">
-                            <img class="object-fit-cover" src="images/events/event-airflow.webp" alt="Airflow Summit Banner">
-                        </div>
-                    </div>
-                    <div class="event-content flex-2 flex flex-column pl-medium">
-                        <h3 class="event-info event-title">Airflow Summit</h3>
-                        <h4 class="event-info event-location">Seattle, Washington, USA</h4>
-                        <h5 class="event-info event-dates">October 7-9, 2025</h5>
-                        <p class="event-info event-description">Connect with top industry professionals and immerse yourself in the Apache Airflow community. Explore over 100 captivating sessions hosted by industry experts—your ultimate source of knowledge and inspiration.</p>
-                        <div class="flex-self-end text-right">
-                            <a class="btn event-link event-info" href="https://airflowsummit.org/" target="_blank">Learn More</a>
-                        </div>
-                    </div>
-                </div>
-	      	</div>
-		    <div class="mySlides event-slide text-left">
-                <div class="flex">
-                    <div class="flex-1 event-info event-image">
-                        <div class="event-image-wrap">
-                             <img class="object-fit-cover" src="images/events/event-flnk-forward.webp" alt="Flink Forward banner">
-                        </div>
-                    </div>
-                    <div class="event-content flex-2 flex flex-column pl-medium">
-                        <h3 class="event-info event-title">Flink Forward</h3>
-                        <h4 class="event-info event-location">Barcelona, Spain</h4>
-                        <h5 class="event-info event-dates">October 13-16, 2025</h5>
-                        <p class="event-info event-description">With a dynamic agenda packed with cutting-edge Flink use cases, training options, and plenty of networking opportunities, Barcelona will provide the perfect backdrop for the global Flink community to connect, learn, and push the boundaries of real-time data streaming.</p>
-                        <div class="flex-self-end text-right">
-                            <a class="btn event-link event-info" href="https://www.flink-forward.org/" target="_blank">Learn More</a>
-                        </div>
-                    </div>
-                </div>
-	      	</div>
-		    <div class="mySlides event-slide text-left">
-                <div class="flex">
-                    <div class="flex-1 event-info event-image">
-                        <div class="event-image-wrap">
-                            <img class="object-fit-cover" src="images/events/event-airflow.webp" alt="NuttX International Workshop banner">
-                        </div>
-                    </div>
-                    <div class="event-content flex-2 flex flex-column pl-medium">
-                        <h3 class="event-info event-title">NuttX International Workshop</h3>
-                        <h5 class="event-info event-dates">October 16-17, 2025</h5>
-                        <p class="event-info event-description">This global gathering brings together developers and users of Apache NuttX® to connect, collaborate, and shape the future of this powerful real-time operating system. This is your chance to meet the community, share ideas, and influence the project’s direction.</p>
-                        <div class="flex-self-end text-right">
-                            <a class="btn event-link event-info" href="https://events.nuttx.apache.org/" target="_blank">Learn More</a>
-                        </div>
-                    </div>
-                </div>
-	      	</div>
-		    <div class="mySlides event-slide text-left">
-                <div class="flex">
-                    <div class="flex-1 event-info event-image">
-                        <div class="event-image-wrap">
-                            <img class="object-fit-cover" src="images/events/event-cloudstack.webp" alt="CloudStack Collaboration Conference banner">
-                        </div>
-                    </div>
-                    <div class="event-content flex-2 flex flex-column pl-medium">
-                        <h3 class="event-info event-title">CloudStack Collaboration Conference</h3>
-                        <h4 class="event-info event-location">Milan, Italy</h4>
-                        <h5 class="event-info event-dates">November 19-21, 2025</h5>
-                        <p class="event-info event-description">The CloudStack Collaboration Conference is an exciting in-person event tailored for the global Apache CloudStack™ community, bringing together developers, users, and technology leaders to explore the latest advancements in open-source cloud and virtualization management.</p>
-                        <div class="flex-self-end text-right">
-                            <a class="btn event-link event-info" href="https://www.cloudstackcollab.org/" target="_blank">Learn More</a>
-                        </div>
-                    </div>
-                </div>
-	      	</div>
+            <!-- Events are defined in data/events.yaml -->
+[for events]<div class="mySlides event-slide text-left">
+    <div class="flex">
+        <div class="flex-1 event-info event-image">
+            <div class="event-image-wrap">
+                <img class="object-fit-cover" src="[events.image]" alt="[events.alt]">
+            </div>
+        </div>
+        <div class="event-content flex-2 flex flex-column pl-medium">
+            <h3 class="event-info event-title">[events.title]</h3>
+            <h4 class="event-info event-location">[events.location]</h4>
+            <h5 class="event-info event-dates">[events.dates]</h5>
+            <p class="event-info event-description">[events.description]</p>
+            <div class="flex-self-end text-right">
+                <a class="btn event-link event-info" href="[events.link]" target="_blank">Learn More</a>
+            </div>
+        </div>
+    </div>
+</div>[end]
             <!-- Next/prev buttons -->
             <a class="prev" onclick="plusSlides(-1)">&#10094;</a>
             <a class="next" onclick="plusSlides(1)">&#10095;</a>
         </div>
-        <!-- Dots/bullets/indicators; there should be one for each event-slide above -->
         <div class="dot-container">
-            <span class="dot" onclick="currentSlide(1)"></span>
-            <span class="dot" onclick="currentSlide(2)"></span>
-            <span class="dot" onclick="currentSlide(3)"></span>
-            <span class="dot" onclick="currentSlide(4)"></span>
+            <!--
+                The if-index clause is a work-round to creates an index
+                of the form 1, 1+1, 1+1+1 etc
+                It may be possible to simplify this later.
+            -->
+            [for events][if-index events first][define _idx]1[end][else][define _idx][_idx]+1[end][end]<span class="dot" onclick="currentSlide([_idx])"></span>[end]
         </div>
         <!-- END SLIDESHOW CONTAINER -->
     </div>

--- a/data/events.yaml
+++ b/data/events.yaml
@@ -1,0 +1,49 @@
+events:
+  - title: Airflow Summit
+    location: Seattle, Washington, USA
+    dates: October 7-9, 2025
+    description: >-
+      Connect with top industry professionals and immerse yourself in the Apache Airflow community.
+      Explore over 100 captivating sessions hosted by industry experts—your ultimate source of knowledge and inspiration.
+    link: https://airflowsummit.org/
+    image: images/events/event-airflow.webp
+    alt: Airflow Summit Banner
+  - title: Flink Forward
+    location: Barcelona, Spain
+    dates: October 13-16, 2025
+    description: >-
+      With a dynamic agenda packed with cutting-edge Flink use cases, training options, and plenty of networking
+      opportunities, Barcelona will provide the perfect backdrop for the global Flink community to connect,
+      learn, and push the boundaries of real-time data streaming.
+    link: https://www.flink-forward.org/
+    image: images/events/event-flnk-forward.webp
+    alt: Flink Forward banner
+  - title: NuttX International Workshop
+    location: Online
+    dates: October 16-17, 2025
+    description: >-
+      This global gathering brings together developers and users of Apache NuttX® to connect, collaborate,
+      and shape the future of this powerful real-time operating system.
+      This is your chance to meet the community, share ideas, and influence the project’s direction.
+    link: https://events.nuttx.apache.org/
+    image: images/events/event-airflow.webp
+    alt: NuttX International Workshop banner
+  - title: CloudStack Collaboration Conference
+    location: Milan, Italy
+    dates: November 19-21, 2025
+    description: >-
+      The CloudStack Collaboration Conference is an exciting in-person event tailored for the global
+      Apache CloudStack™ community, bringing together developers, users, and technology leaders to explore
+      the latest advancements in open-source cloud and virtualization management.
+    link: https://www.cloudstackcollab.org/
+    image: images/events/event-cloudstack.webp
+    alt: CloudStack Collaboration Conference banner
+# Sample entry:
+# - title: TBA
+#   location: TBA
+#   dates: TBA
+#   description: >-
+#     TBA
+#   link: TBA
+#   image: TBA
+#   alt: TBA


### PR DESCRIPTION
It's easier to maintain a YAML file than parts of a large HTML file.

ALso, once there is a central event resource (e.g. Google Calendar with extra details) it will be easy to update the source of the data.

The changed data can be seen at:

https://www-sebb-events.staged.apache.org/#upcoming-events