### PR TITLE
Remove 'foundationproject' anchor

### DIFF
--- a/content/foundation/foundation-projects.md
+++ b/content/foundation/foundation-projects.md
@@ -1,5 +1,5 @@
 Title: Foundation Projects
-page_heading: What are Foundation 'Projects'?  {#foundationproject}
+page_heading: What are Foundation 'Projects'?
 license: https://www.apache.org/licenses/LICENSE-2.0
 
 To support our hundreds of Apache software project communities, the Apache Software


### PR DESCRIPTION
Apparently anchoris in page headings don't / no longer work (https://www.apache.org/foundation/foundation-projects.html) and nothing seems to be referring to this anyway.