### PR TITLE
Turn on basic branch protections via .asf.yaml

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -7,6 +7,8 @@ github:
     squash: true
     merge: false
     rebase: false
+  protected_branches:
+    main: {}
 
 notifications:
   commits: site-cvs@apache.org


### PR DESCRIPTION
This change should enable basic branch protections on the `main` branch. This should require that individuals commit to a separate branch, PR that branch, and then get someone else to merge it in for them.