### PR TITLE
Replace "Sponsorship" button with "Donate" button linking to donate.apache.org

### DIFF
--- a/theme/apache/templates/base.html
+++ b/theme/apache/templates/base.html
@@ -184,7 +184,7 @@ s=d.getElementsByTagName('script')[0];
                 </li>
                 
             
-                <li><a href="/foundation/sponsorship" class="btn">Sponsor</a></li>
+                <li><a href="https://donate.apache.org/" class="btn">Donate</a></li>
                 <li class="dropdown">
                 <a href="#" class="dropdown-toggle hidden-xs" data-toggle="dropdown" role="button"><span class="glyphicon glyphicon-search"
                     aria-hidden="true"></span><span class="sr-only">Search</span></a>


### PR DESCRIPTION
This PR updates the "Sponsorship" button on the homepage to "Donate" and links it to https://donate.apache.org/, as requested in Giving Campaign #580

I noticed this is usually handled by @Paul-TT, but since the update is minor and November has already begun, I’ve submitted this PR to help keep the site current. 
Please feel free to review or adjust as needed.