### PR TITLE
Trivial typo correction

### DIFF
--- a/theme/apache/templates/base.html
+++ b/theme/apache/templates/base.html
@@ -29,7 +29,7 @@
   <meta name="msapplication-config" content="/favicons/browserconfig.xml">
   <meta name="theme-color" content="#282661">
 
-  <title>{{ page.title }} | Apache Software Foundations</title>
+  <title>{{ page.title }} | Apache Software Foundation</title>
   <link href="/css/Montserrat-300-600-800.css" async rel="stylesheet">
   <link href="/css/OpenSans.css" async rel="stylesheet">
   <link href="/css/min.bootstrap.css" async rel="stylesheet">


### PR DESCRIPTION
"Apache Software Foundations" appears in the base template. Should be "Apache Software Foundation"