### PR TITLE
Fix empty meta description by falling back to site description

### DIFF
--- a/theme/apache/templates/base.html
+++ b/theme/apache/templates/base.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   {% if page.description %}
   <meta name="description" content="{{ page.description }}">
-  {% elif site.description %}
+  {% elif site is defined and site.description %}
   <meta name="description" content="{{ site.description }}">
   {% endif %}
   {% if page.noindex == 'true' %}


### PR DESCRIPTION
Some pages render an empty meta description when `page.description` is not set.

This change updates the base template to fall back to the site-wide description
defined in pelicanconf.yaml, ensuring meta description tags are never empty and
improving SEO consistency across the site.

Fixes #595.
