### PR TITLE
Added clarification per LEGAL-651

### DIFF
--- a/content/licenses/LICENSE.txt
+++ b/content/licenses/LICENSE.txt
@@ -1,3 +1,12 @@
+This url was linked from early Apache HTTP Server software releases.
+Many links to this license are likely looking for the Apache Software
+License 1.1, which can be found officially at:
+
+    https://www.apache.org/licenses/LICENSE-1.1
+
+A copy of the text originally found at this location is included below
+for historical purposes:
+
 /* ====================================================================
  * The Apache Software License, Version 1.1
  *


### PR DESCRIPTION
LICENSE.txt is an odd one. It's actually the HTTP Server's license file, not the generic Apache license file. This note clarifies this situation.