### PR TITLE
Exclude header and footer from pagefind analysis

### DIFF
--- a/theme/apache/templates/base.html
+++ b/theme/apache/templates/base.html
@@ -94,7 +94,7 @@ s=d.getElementsByTagName('script')[0];
 <body{% if page.bodytag %} {{ page.bodytag }}{% endif %} >
   
   <!-- Navigation -->
-  <header id="top-header">
+  <header id="top-header" data-pagefind-ignore="all">
     <div class="header-banner">
         <div class="inner text-center">
             <p>Introducing The ASF’s New Logo <a href="https://news.apache.org/foundation/entry/introducing-the-asfs-new-logo" target="_blank">Read Now</a></p>
@@ -271,7 +271,7 @@ s=d.getElementsByTagName('script')[0];
   </div>
   <!-- Footer -->
    <!-- Bump -->
-  <footer class="bg-primary">
+  <footer class="bg-primary" data-pagefind-ignore="all">
     <div class="inner py-xl">
         <div class="flex gap-large mb-large flex-column-800">
             <div class="flex-1 flex flex-column gap-medium">


### PR DESCRIPTION
At present, the contents of page headers and footers are included in the pagefind search.

This means that it is very difficult to search for actual references to words that appear in a header or footer.
For example, a search for Newsroom generates 175 hits, most of which are just links.

However, with the PR applied, there are just two hits:
https://www-search-body-only.staged.apache.org/
