### PR TITLE
Update and pin checkout GitHub action by sha

### DIFF
--- a/.github/workflows/members_check.yml
+++ b/.github/workflows/members_check.yml
@@ -19,7 +19,7 @@ jobs:
   members-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Check members.md for discrepancies
         run: |
           echo "${{ github.event_name }}"


### PR DESCRIPTION
For security reason and ASF policy, sha should be used as version for actions.