### PR TITLE
Automatically delete branch after merge

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -7,6 +7,9 @@ github:
     squash: true
     merge: false
     rebase: false
+  pull_requests:
+    # auto-delete head branches after being merged
+    del_branch_on_merge: true
   protected_branches:
     main: 
       required_pull_request_reviews:


### PR DESCRIPTION
I see about 20+ branches which have been already merged .... IMHO it is not needed to preserve such branches

https://github.com/apache/www-site/branches/all

