### PR TITLE
Add link to /press/media page in press section

### DIFF
--- a/content/press/index.md
+++ b/content/press/index.md
@@ -4,6 +4,7 @@ license: https://www.apache.org/licenses/LICENSE-2.0
 ## Recent News 
 <p><a class="btn btn-default mx-10" href="https://news.apache.org/" role="button">Go to Foundation Newsroom</a>
 <p><a class="btn btn-default mx-10" href="https://apache.org/foundation/reports" role="button">View Reports</a>
+<p><a class="btn btn-default mx-10" href="/press/media" role="button">Media Resources</a>
 
 ## Publicity Guidelines for ASF Top-Level Projects
 ASF top-level projects (TLPs) and their communities are encouraged to actively build awareness of their project and activities through marketing and communications activities such as public relations, email, content, social media, website, and branding. Educational opportunities include Community Over Code, meetups, videos, podcasts, articles, third party conferences, and related community events.


### PR DESCRIPTION
## What does this PR do?
Adds a navigation link to the `/press/media` page in the press section to improve accessibility and discoverability.

## Why is this change needed?
The `/press/media` page exists but is not linked from anywhere on the website, making it difficult for users to find.

## What has been done?
- Added a "Media Resources" button linking to `/press/media` in `content/press/index.md`
- Followed existing UI structure for consistency

## Additional Context
The previously reported broken internal link has already been resolved, but the page remained unlinked. This PR addresses that gap.

## Related Issue
Fixes #404

Before Changes:
<img width="927" height="130" alt="image" src="https://github.com/user-attachments/assets/4e6c6260-c255-415a-a70f-6c8d6177bd0b" />

After Changes:
<img width="967" height="164" alt="image" src="https://github.com/user-attachments/assets/e2afc2e4-4c1a-4747-9903-642656100311" />
