### PR TITLE
Update `security.txt` expiration date

### DIFF
--- a/content/.well-known/security.txt
+++ b/content/.well-known/security.txt
@@ -5,4 +5,4 @@ Policy: https://security.apache.org/report/
 Preferred-Languages: en
 
 # https://www.rfc-editor.org/rfc/rfc9116#section-2.5.5
-Expires: 2026-03-18T00:00:00Z
+Expires: 2026-04-09T08:21:50Z


### PR DESCRIPTION
The current `security.txt` file has expired on March 18th. This change extends the expiration date for another year.