### PR TITLE
Include additional link to Project Download Page in release policy

### DIFF
--- a/content/legal/release-policy.md
+++ b/content/legal/release-policy.md
@@ -355,7 +355,8 @@ Please ensure that you wait at least one hour after uploading a new release
 before updating the project download page and sending the announcement email(s). 
 
 It is important to inform people about the availability of new
-releases. Announcements must contain a link to the Project Download Page for the source.
+releases. Announcements must contain a link to the
+[Project Download Page](https://infra.apache.org/release-download-pages.html) for the source.
 At the very least, emails should be sent out announcing this to
 all appropriate mailing lists. Many top level projects have announcement
 lists for this purpose. There is also an


### PR DESCRIPTION
Added a link to the Project Download Page in the release announcement guidelines.

closes #703 