### PR TITLE
Add Apache Flink to the export classifications matrix

### DIFF
--- a/data/eccn/eccnmatrix.yaml
+++ b/data/eccn/eccnmatrix.yaml
@@ -518,6 +518,34 @@ eccnmatrix:
               - href: 'https://jetty.org'
                 manufacturer: The Eclipse Foundation
                 why: HTTPS support in Jetty (uses SSL)
+  - href: 'https://flink.apache.org/'
+    name: Apache Flink Project
+    contact: Apache Flink PMC <private@flink.apache.org>
+    product:
+      - name: Apache Flink
+        versions:
+          - version: development and all releases
+            eccn: 5D002
+            source:
+              - href: 'https://gitbox.apache.org/repos/asf/flink.git'
+                manufacturer: ASF
+                why: Designed for use with Java Secure Socket Extension (JSSE)
+      - name: Apache Flink Shaded
+        versions:
+          - version: development and all releases
+            eccn: 5D002
+            source:
+              - href: 'https://gitbox.apache.org/repos/asf/flink-shaded.git'
+                manufacturer: ASF
+                why: Designed for use with OpenSSL (relocated netty-tcnative packaging)
+              - href: 'https://openssl-library.org/source/'
+                manufacturer: The OpenSSL Project
+                why: Publicly available SSL encryption library
+              - href: 'https://boringssl.googlesource.com/boringssl'
+                manufacturer: Google
+                why: >-
+                  Publicly available SSL encryption library (BoringSSL,
+                  embedded in the static netty-tcnative variant)
   - href: 'http://forrest.apache.org/'
     name: Apache Forrest Project
     contact: Apache Forrest PMC <private@forrest.apache.org>


### PR DESCRIPTION
Flink's binary distribution has carried the standard ASF cryptographic notice self-classifying as ECCN 5D002.C.1 since 2011 (see https://github.com/apache/flink/blame/master/flink-dist/src/main/flink-bin/README.txt), but the project was never added to this matrix.

The entry covers two products, reflecting current state:

- Apache Flink: designed for use with the built-in Java TLS/SSL (JSSE) libraries
- Apache Flink Shaded: publishes flink-shaded-netty-tcnative-dynamic (links against OpenSSL) and flink-shaded-netty-tcnative-static (embeds Google's BoringSSL), hence the additional manufacturer rows for The OpenSSL Project and Google.