### PR TITLE
Update conduct.ezmd

### DIFF
--- a/content/foundation/policies/conduct.ezmd
+++ b/content/foundation/policies/conduct.ezmd
@@ -63,7 +63,7 @@ Assume good faith; it is more likely that participants are unaware of their bad 
  
  * [[]President](https://whimsy.apache.org/foundation/orgchart) of The Apache Software Foundation: [{ ci[president][roster] }] (president AT apache DOT org)
  * [[]Executive Vice President](https://whimsy.apache.org/foundation/orgchart) of The Apache Software Foundation: [{ ci[execvp][roster] }] ([{ ci[execvp][availid] }] AT apache DOT org)
- * [[]Vice President, Diversity and Inclusion]: Daniel Gruno (humbedooh AT apache DOT org)
+ * [[]Vice President, Diversity and Inclusion](https://whimsy.apache.org/foundation/orgchart): Daniel Gruno (humbedooh AT apache DOT org)
 
 
 If the violation is in documentation or code, for example, inappropriate pronoun usage or word choice within official documentation, report these privately to the project in question at private@<em>project</em>.apache.org, and, if you have sufficient ability within the project, resolve or remove the concerning material, being mindful of the perspective of the person originally reporting the issue.


### PR DESCRIPTION
Followup to #712. Although it balanced the brackets it didn't render very well (and I can only blame myself not understanding ezmd). Try to add a link to the org chart, as in the links to Prez and EVP.

Another option would be to remove the brackets completely (leaving VP D&I without a link at all).