### PR TITLE
Render the board's minutes as pages, the way calendar.md is rendered

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 site-generated
 pelican.auto.py
 content/foundation/board/calendar.md
+content/foundation/board/minutes/
 __pycache__/
 .idea
 .DS_Store

--- a/get_minutes.sh
+++ b/get_minutes.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# The board's minutes as pages: one per meeting, one per committee, and an index over both.
+# Generated from the published record by the Board Agenda Tool and committed to SVN beside
+# calendar.md, so this is the same arrangement get_calendar.sh already uses - the tool writes
+# markdown into SVN, and the site build renders it with everything else.
+#
+# Absent is not an error. The tool only writes these once it is switched on to, and that switch is
+# thrown after this wiring is in place, so there is a window where the directory does not exist
+# yet. Failing hard there would break every build of the whole site over a directory nothing is
+# serving from.
+
+MINUTES=https://svn.apache.org/repos/asf/infrastructure/site/trunk/content/foundation/board/minutes
+
+echo "Fetching board minutes from SVN"
+cd content/foundation/board || exit
+
+if /usr/bin/svn ls "$MINUTES" > /dev/null 2>&1; then
+    /usr/bin/svn export "$MINUTES" --force
+else
+    echo "Nothing published at $MINUTES yet - skipping"
+fi

--- a/pelicanconf.yaml
+++ b/pelicanconf.yaml
@@ -19,6 +19,7 @@ setup:
   data: asfdata.yaml
   run:
     - /bin/bash get_calendar.sh
+    - /bin/bash get_minutes.sh
   postrun:
     - /bin/bash pagefind.sh
   ignore:


### PR DESCRIPTION
## What this does

Renders the board's minutes as pages of this site, using the same arrangement `calendar.md`
already uses: a script in `setup.run` exports markdown from SVN before the build, Pelican renders
it with everything else, and the output is gitignored because it is generated rather than written.

| | |
| --- | --- |
| `get_minutes.sh` | new, alongside `get_calendar.sh` |
| `pelicanconf.yaml` | one line in `setup.run` |
| `.gitignore` | `content/foundation/board/minutes/`, next to the existing `calendar.md` entry |

The pages are generated from the published minutes by the Board Agenda Tool
([apache/tooling-agenda#54](https://github.com/apache/tooling-agenda/issues/54)) and committed to
SVN beside `calendar.md`. There are three kinds, all under `/foundation/board/minutes/`:

```
minutes/index.html                            the index: years, then committees
minutes/2025/index.html                       one year
minutes/2025/board_minutes_2025_06_18.html    one meeting
minutes/Tomcat.html                           one committee, its whole history
```

Today those two views are served by whimsy, at `/board_minutes/<year>/...` and
`/board/minutes/<Name>.html`. The generating side reproduces whimsy's filenames and anchors
exactly, because www.apache.org already links to them by name, and it emits a matching
`.htaccess` of redirects so every URL whimsy serves keeps working. That is what lets whimsy be
retired rather than kept alongside.

## Absent is not an error

`svn ls` first, and skip with a message if the directory is not there.

The tool writes these pages only once it is configured to, and that switch is thrown *after* this
wiring exists - otherwise it would be publishing into a site that does not render them. So there
is a window, starting when this merges, where the SVN path does not exist yet. A bare
`svn export` would exit non-zero for the whole build over a directory nothing is serving from.

Verified both ways against the real SVN: the skip path exits 0 today, and `svn export` of an
existing path creates the directory named for the final URL segment, which is what puts the pages
at `content/foundation/board/minutes/`. `shellcheck` is clean.

## Not in this PR

The minutes **text** stays where it is. `/foundation/records/minutes/` is proxied to
svn.apache.org by `content/foundation/records/.htaccess`, and this changes nothing about that -
the rendered pages link out to it as they do now.

Bringing the `.txt` alongside the rendered pages and retiring that proxy is a second pass. Two
things to know when it happens:

- that `.htaccess` covers all of `/foundation/records/`, including the IRS 990 PDFs, so it cannot
  simply be deleted
- `/foundation/records/minutes` without a trailing slash currently **301s to svn.apache.org**,
  because the proxied backend issues its own `DirectorySlash` redirect and nothing rewrites it
  back - so the hostname leaks into the address bar today

## Draft

Draft until the generating side lands. Nothing here serves anything until the tool is switched on
to publish, so merging it early is safe - but reviewing it against the pages it will render is
easier once those exist.
