### PR TITLE
Replace Code of Conduct

### DIFF
--- a/content/foundation/policies/conduct.ezmd
+++ b/content/foundation/policies/conduct.ezmd
@@ -1,88 +1,172 @@
 Title:     Code of Conduct
 license: https://www.apache.org/licenses/LICENSE-2.0
 
+## Our Pledge
 
+We, as participants in the Apache Software Foundation, including contributors,
+committers, Project Management Committee (PMC) members, ASF Members, and
+officers, pledge to make participation in our community a harassment-free
+experience for everyone, regardless of age, body size, visible or invisible
+disability, ethnicity, sex characteristics, gender identity and expression,
+level of experience, education, socio-economic status, nationality, personal
+appearance, race, caste, color, religion, or sexual identity and orientation.
 
-## Introduction
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
 
-This code of conduct applies to all spaces the Apache Software Foundation manages, including IRC, public and private mailing lists, issue trackers, wikis, blogs, Twitter, and any other communication channels our communities use. A code of conduct which is specific to in-person events (ie., conferences) is in the ASF [[]anti-harassment policy](anti-harassment.html).
+## Our Standards
 
-We expect everyone who participates in the Apache community formally or informally, or claims any affiliation with the Foundation, in any Foundation-related
-activities and especially when representing the ASF in any role to honor this code of conduct.
+Examples of behavior that contributes to a positive environment for our
+community include:
 
-This code <u>is not exhaustive or complete</u>. It distills our common understanding of a collaborative, shared environment and goals. 
-We expect all members of the Apache community to follow it in spirit as much as in the letter, so that it can enrich all of us and the technical communities in which we participate.
+* Demonstrating empathy and kindness toward others
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the ASF and
+  the overall community
 
-## Specific Guidelines
+Examples of unacceptable behavior include:
 
-We strive to:
+* The use of sexualized language or imagery, and unwelcome sexual attention
+  or advances
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information (such as a physical or email address)
+  without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional or open source setting
 
+## Enforcement Responsibilities
 
-1. __Be open.__ We invite anyone to participate in our community. We prefer to use public methods of communication for project-related messages, unless discussing something sensitive. This applies to messages for help or project-related support, too; not only is a public support request much more likely to result in an answer to a question, it also makes sure that the community notices and corrects any inadvertent mistakes people answering the query may make.
+Each ASF Project Management Committee (PMC) is responsible for clarifying and
+enforcing standards of acceptable behavior within their community, and may
+take appropriate and fair corrective action in response to any behavior that
+is inconsistent with this Code of Conduct.
 
-2. __Be <a href="#endnotes">empathetic</a>, welcoming, friendly, and patient.__ We work together to resolve conflicts, assume good intentions, and do our best to act in an empathetic fashion. We may all experience some frustration from time to time, but we do not allow frustration to result in a personal attack. A community where people feel uncomfortable or threatened is not a productive one. We should be respectful when dealing with other community members as well as with people outside our community.
+PMC members have the right and responsibility to remove or reject comments,
+commits, code, wiki edits, issues, and other contributions that are not
+aligned with this Code of Conduct, and to communicate reasons for their
+decisions when appropriate.
 
-3. __Be collaborative.__ Other people will use our work, and we in turn depend on the work of others. When we make something for the benefit of the project, we are willing to explain to others how it works, so they can build on the work to make it even better. Any decision we make will affect users and colleagues, and we take those consequences seriously when making decisions.
+For matters that go beyond the scope of a single project or raise
+Foundation-wide concerns, the ASF President (or their designee) may investigate
+and take appropriate action, or escalate to the ASF Board or an ASF Officer if
+necessary.
 
-4. __Be inquisitive.__ Nobody knows everything! Asking questions early avoids many problems later, so we encourage questions, although we may redirect them to the appropriate forum. Those who receive a question should be responsive and helpful, within the context of our shared goal of improving Apache project code.
+## Recusal
 
-5. __Be careful in the words that we choose.__ Whether we are participating as professionals or volunteers, we value professionalism in all interactions, and take responsibility for our own speech. Be kind to others. Do not insult or put down other participants. Harassment and other exclusionary behaviour are not acceptable. This includes, but is not limited to:
-    * Violent threats or language directed against another person.
-    * Sexist, racist, or otherwise discriminatory jokes and language.
-    * Posting sexually explicit or violent material.
-    * Posting (or threatening to post) other people's personally identifying information ("doxing").
-    * Sharing private content, such as emails sent privately or non-publicly, or from unlogged forums such as IRC channel history.
-    * Personal insults, especially those using racist or sexist terms.
-    * Unwelcome sexual attention.
-    * Excessive or unnecessary profanity.
-    * Repeated harassment of others. In general, if someone asks you to stop, then stop.
-    * Advocating for, or encouraging, any of the above behaviour.
+To preserve fairness and avoid conflicts of interest, any PMC member,
+ASF officer, or Member who is directly involved in or personally connected to
+a reported incident must recuse themselves from participating in the review,
+decision-making, or enforcement process. This includes cases where the
+individual is a party to the report, has a close personal or professional
+relationship with one of the parties, or may otherwise be perceived as lacking
+impartiality. In such circumstances, responsibility for handling the report
+should be delegated to uninvolved PMC members or escalated as appropriate.
 
-6. __Be concise.__ Keep in mind that, over time, hundreds or thousands of people will read what you write. Writing a short email means people can understand the conversation as efficiently as possible. Short emails should always strive to be empathetic, welcoming, friendly and patient. When a long explanation is necessary, consider adding a summary at the top of the message.<br/><br/>
-Try to bring new ideas to a conversation so that each email adds something unique to the thread, keeping in mind that the rest of the thread still contains the other messages with arguments that have already been made.<br/><br/>
-Try to stay on topic, especially in discussions that are already fairly long.
+## Scope
 
-7. __Step down considerately.__ Members of every project come and go. When somebody leaves or disengages from the project they should tell people they are leaving and take the proper steps to ensure that others can pick up where they left off. In doing so, they should remain respectful of those who continue to participate in the project and should not misrepresent the project's goals or achievements. Likewise, community members should respect any individual's choice to leave the project.
-
-
-## Diversity Statement
-
-Apache welcomes and encourages participation by everyone. We are committed to being a community that everyone feels good about joining. Although we may not be able to satisfy everyone, we will always work to treat everyone well.
-
-No matter how you identify yourself or how others perceive you, we welcome you. Though no list can hope to be comprehensive, we explicitly honour diversity in age, culture, ethnicity, genotype, gender identity or expression, language, national origin, neurotype, phenotype, political beliefs, profession, race, religion, sexual orientation, socioeconomic status, subculture and technical ability.
-
-Though we welcome people fluent in all languages, Apache software development takes place in English.
-
-The Code of Conduct, above, details our standards for behaviour in the Apache community. We expect participants in our community to meet these standards in all their interactions and to help others to do so.
+This Code of Conduct applies to all ASF projects, mailing lists, source code
+repositories, issue trackers, events, chat services and community spaces,
+whether official or unofficial, and also applies when individuals are
+representing ASF or its projects in public spaces. Representation may include
+using an official ASF email address, posting via an official project or
+Foundation social media account, or serving as a delegate at an online or
+offline event. It also applies to ASF-wide channels, including the
+members@apache.org mailing list, ASF chat services, and other internal
+platforms.
 
 ## Reporting Guidelines
 
-While all participants should adhere to this code of conduct, we recognize that sometimes people may have a bad day, or be unaware of some of the code's guidelines. When that happens, you may reply to them and point out this code of conduct. Such messages may be in public or in private, whatever is most appropriate. However, regardless of whether the message is public or not, it should still adhere to the relevant parts of this code of conduct; in particular, it should not be abusive or disrespectful.
+While all participants should adhere to this Code of Conduct, we recognize that
+people may have a bad day or be unaware of the guidelines. When that happens,
+you may respond by pointing out the Code of Conduct. This can be done in public
+or private, as appropriate, but all responses should themselves remain
+respectful and constructive.
 
-Assume good faith; it is more likely that participants are unaware of their bad behaviour than that they intentionally try to degrade the quality of the discussion. Should there be difficulties in dealing with the situation, you may report your compliance issues in confidence to:
- 
- * [[]President](https://whimsy.apache.org/foundation/orgchart) of The Apache Software Foundation: [{ ci[president][roster] }] (president AT apache DOT org)
- * [[]Executive Vice President](https://whimsy.apache.org/foundation/orgchart) of The Apache Software Foundation: [{ ci[execvp][roster] }] ([{ ci[execvp][availid] }] AT apache DOT org)
- * [[]Vice President, Diversity and Inclusion](https://whimsy.apache.org/foundation/orgchart): Daniel Gruno (humbedooh AT apache DOT org)
+Assume good faith: it's more likely someone is unaware of how their behavior
+was received than intentionally trying to be harmful.
 
+For issues that are specific to a single ASF project, reports may be directed
+to that project's Project Management Committee (PMC), typically via its private
+mailing list (e.g., `private@project.apache.org`).
 
-If the violation is in documentation or code, for example, inappropriate pronoun usage or word choice within official documentation, report these privately to the project in question at private@<em>project</em>.apache.org, and, if you have sufficient ability within the project, resolve or remove the concerning material, being mindful of the perspective of the person originally reporting the issue.
+If you are unable to resolve the situation, or feel unsafe or uncomfortable
+addressing it, you may report compliance issues in confidence to:
 
+* **President of The Apache Software Foundation** ([president@apache.org](mailto:president@apache.org))
+* **Executive Vice President of The Apache Software Foundation**
+* Or one of the ASF's designated volunteers
 
-<h2 id="endnotes">Notes</h2>
+The President (or a designated officer) may refer a report to the relevant PMC
+if the issue is project-specific, or handle it directly in Foundation-wide
+cases. Privacy and discretion will be respected in all cases.
 
-This Code defines __empathy__ as "a vicarious participation in the emotions, ideas, or opinions of others; the ability to imagine oneself in the condition or predicament of another." __Empathetic__ is the adjectival form of empathy.
+If the concern is about inappropriate content in documentation or code (e.g.,
+inappropriate language), please report it privately to the project's private
+mailing list (e.g., `private@project.apache.org`). If you have the necessary
+access, consider resolving or removing the concerning material with sensitivity
+to the perspective of the reporter.
 
+## Enforcement Process
 
-This statement draws on the following for content and inspiration:
+When a Code of Conduct concern is raised, ASF officers or PMCs will assess the
+issue and determine the appropriate response using the following guidelines.
 
+**Note on Frivolous or Malicious Complaints**
+The ASF values and encourages good-faith reporting of concerns. While most
+reports are raised constructively, knowingly filing false or malicious
+complaints, or repeatedly misusing the reporting process, may itself be
+treated as a violation of this Code of Conduct.
 
-  * [[]CouchDB Project Code of conduct](http://couchdb.apache.org/conduct.html)
-  * [[]Fedora Project Code of Conduct](http://fedoraproject.org/code-of-conduct)
-  * [[]Speak Up! Code of Conduct](http://speakup.io/coc.html)
-  * [[]Django Code of Conduct](https://www.djangoproject.com/conduct/)
-  * [[]Debian Code of Conduct](http://www.debian.org/vote/2014/vote_002)
-  * [[]Twitter Open Source Code of Conduct](https://github.com/twitter/code-of-conduct/blob/master/code-of-conduct.md)
-  * [[]Mozilla Code of Conduct/Draft](https://wiki.mozilla.org/Code_of_Conduct/Draft#Conflicts_of_Interest)
-  * [[]Python Diversity Appendix](https://www.python.org/community/diversity/)
-  * [[]Python Mentors Home Page](http://pythonmentors.com/)
+**1\. No Action**
+*Community Impact*: Concerns raised do not represent a violation or do not rise
+to the level of requiring intervention.
+*Consequence*: No formal correction steps; may include an informational
+clarification for awareness.
+
+**2\. Correction**
+*Community Impact*: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+*Consequence*: A private, written warning, providing clarity around the nature
+of the violation and an explanation of why the behavior was inappropriate. A
+public apology may be requested.
+
+**3\. Warning**
+*Community Impact*: A violation through a single incident or series of actions.
+*Consequence*: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding community spaces and external channels like social media.
+Violating these terms may lead to a temporary or permanent ban.
+
+**4\. Temporary Ban**
+*Community Impact*: A serious violation of community standards, including
+sustained inappropriate behavior.
+*Consequence*: A temporary ban from any public interaction with the community.
+No public or private interaction with the people involved, including
+unsolicited interaction with those enforcing the Code of Conduct, is allowed
+during this period. Violating these terms may result in a permanent ban.
+
+**5\. Permanent Ban**
+*Community Impact*: A pattern of violating community standards, including
+sustained inappropriate behavior, harassment of an individual, or aggression
+toward or disparagement of classes of individuals.
+*Consequence*: A permanent ban from any form of public interaction within
+the community.
+
+In the case of ASF Members, any such action must be consistent with
+[ASF Bylaw 4.7](https://www.apache.org/foundation/bylaws.html#termination),
+which requires a vote of the Membership to terminate ASF membership. A PMC or
+ASF Officer may recommend a temporary exclusion from specific channels or
+events pending that process.
+
+## Attribution
+
+This Code of Conduct is adapted from the Contributor Covenant, version 2.1,
+available at [https://www.contributor-covenant.org/version/2/1/code\_of\_conduct.html](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).
+
+Community Impact Guidelines were inspired by Mozilla's code of conduct
+enforcement ladder.


### PR DESCRIPTION
Updates Code of Conduct to the version which was approved by the Board of Directors in the August 19 2026 board meeting.