### PR TITLE
Remove Community Over Code Beijing 2026 event details

### DIFF
--- a/content/index.ezmd
+++ b/content/index.ezmd
@@ -168,24 +168,6 @@ bodytag: id="home"
                 <div class="flex">
                     <div class="flex-1 event-info event-image">
                         <div class="event-image-wrap">
-                            <img class="object-fit-cover" src="images/events/2026-banner-bg-v1.jpg" loading="lazy" alt="Community Over Code Beijing banner">
-                        </div>
-                    </div>
-                    <div class="event-content flex-2 flex flex-column pl-medium">
-                        <h3 class="event-info event-title">Community Over Code Beijing 2026</h3>
-                        <h4 class="event-info event-location">Beijing, China</h4>
-                        <h5 class="event-info event-dates">August 7-9, 2026</h5>
-                        <p class="event-info event-description">Community Over Code Beijinh 2026 is a three-day conference with diverse and interesting talks, bringing communities together to learn, network, and share experiences in the ASF ecosytem.</p>
-                        <div class="flex-self-end text-right">
-                            <a class="btn event-link event-info" href="https://asia.communityovercode.org/" target="_blank">See Event</a>
-                        </div>
-                    </div>
-                </div>
-	      	</div>
-            <div class="mySlides event-slide text-left">
-                <div class="flex">
-                    <div class="flex-1 event-info event-image">
-                        <div class="event-image-wrap">
                             <img class="object-fit-cover" src="images/events/event-hero-glasgow.webp" loading="lazy" alt="Community Over Code Glasgow hero">
                         </div>
                     </div>


### PR DESCRIPTION
Removed details for the Community Over Code Beijing 2026 event, including image, title, location, dates, description, and link.