### PR TITLE
Fix typo in class name from 'objec' to 'object'

### DIFF
--- a/content/index.ezmd
+++ b/content/index.ezmd
@@ -98,7 +98,7 @@ bodytag: id="home"
         <div class="project-cards mb-large">
              [for featured_projs]<div class="logo-card" id="[featured_projs.key_id]">
                 <a href="[featured_projs.site]" target="_blank" title="[featured_projs.display_name]">
-                    <img class="objec-fit-cover" src="https://www.apache.org[featured_projs.logo]" title="[featured_projs.display_name]" loading="lazy" alt="[featured_projs.display_name]">
+                    <img class="object-fit-cover" src="https://www.apache.org[featured_projs.logo]" title="[featured_projs.display_name]" loading="lazy" alt="[featured_projs.display_name]">
                 </a>
             </div>[end]
         </div>
@@ -107,7 +107,7 @@ bodytag: id="home"
         <div id="incubating-projects" class="project-cards mb-large">
              [for featured_pods]<div class="logo-card" id="[featured_pods.key_id]">
                 <a href="[featured_pods.homepage]" target="_blank" title="[featured_pods.name]">
-                   <img class="objec-fit-cover" src="https://www.apache.org[featured_pods.logo]" title="[featured_pods.name]" loading="lazy" alt="[featured_pods.name]">
+                   <img class="object-fit-cover" src="https://www.apache.org[featured_pods.logo]" title="[featured_pods.name]" loading="lazy" alt="[featured_pods.name]">
                 </a>
             </div>[end]
         </div>
@@ -290,7 +290,7 @@ bodytag: id="home"
     var sponsorHTML = '';
     selectedSponsors.forEach(function(sponsor) {
         sponsorHTML += '<div class="logo-card logo-card--sponsor">';
-        sponsorHTML += '<img class="objec-fit-cover" loading="lazy" src="' + sponsor.logo + '" alt="' + sponsor.name + '">';
+        sponsorHTML += '<img class="object-fit-cover" loading="lazy" src="' + sponsor.logo + '" alt="' + sponsor.name + '">';
         sponsorHTML += '</div>';
     });
     const sponsorLogos = document.getElementById('sponsor-logos');


### PR DESCRIPTION
This affects the object-fit setting for project, podlings and sponsor logo images.
The default is fit, which causes images to be stretched to fit if their aspect ratio does not match the container, whereas cover causes clipping [1]

Preview at https://www-objec-fit-cover.staged.apache.org/

Any differences are likely to be quite subtle, but there is no point adding a non-existent class to images.
Either fix the name (as per this PR) or drop it.

[1] https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/object-fit