### PR TITLE
Revise release policy FAQ for Apache Trusted Releases

### DIFF
--- a/content/legal/release-policy.md
+++ b/content/legal/release-policy.md
@@ -408,7 +408,7 @@ Test packages are for use by consenting developers and interested community
 members only, so they should not be hosted or linked on pages intended for end
 users, or released using a `closer.lua` script.
 
-Projects should use either the new [Apache Trusted Releases](https://releases.apache.org) platform or
+Projects should use either the new [Apache Trusted Releases](https://releases.apache.org) platform or the
 [`/dev` tree of the `dist` repository](https://dist.apache.org/repos/dist/dev) to stage releases.
 The staging features of repository.apache.org may be used
 to host release candidates posted for developer testing/voting (prior to being,

--- a/content/legal/release-policy.md
+++ b/content/legal/release-policy.md
@@ -408,9 +408,9 @@ Test packages are for use by consenting developers and interested community
 members only, so they should not be hosted or linked on pages intended for end
 users, or released using a `closer.lua` script.
 
-Projects should use the 
-[`/dev` tree of the `dist` repository](https://dist.apache.org/repos/dist/dev)
-or the staging features of repository.apache.org
+Projects should use either the new [Apache Trusted Releases](https://releases.apache.org) platform or
+[`/dev` tree of the `dist` repository](https://dist.apache.org/repos/dist/dev) to stage releases.
+The staging features of repository.apache.org may be used to hist releases.
 to host release candidates posted for developer testing/voting (prior to being,
 potentially, formally blessed as a GA release).
 
@@ -461,6 +461,11 @@ If Apache Foo 1.2 is a new branch, and development continues on 1.1 in
 parallel, then it is acceptable to serve both 1.1.a and 1.2.x from `/dist`.
 
 #### How do I upload a release ?  {#upload-ci}
+
+If you use the new [Apache Trusted Releases](https://releases.apache.org) platform then your release artifacts
+will be written to the appropriate subdirectory of the
+[`https://dist.apache.org/repos/dist/release/`](https://dist.apache.org/repos/dist/release/)
+repository.
 
 By committing your release tarballs to the appropriate subdirectory (i.e. TLP name) of the
 [`https://dist.apache.org/repos/dist/release/`](https://dist.apache.org/repos/dist/release/)

--- a/content/legal/release-policy.md
+++ b/content/legal/release-policy.md
@@ -410,7 +410,7 @@ users, or released using a `closer.lua` script.
 
 Projects should use either the new [Apache Trusted Releases](https://releases.apache.org) platform or
 [`/dev` tree of the `dist` repository](https://dist.apache.org/repos/dist/dev) to stage releases.
-The staging features of repository.apache.org may be used to hist releases.
+The staging features of repository.apache.org may be used
 to host release candidates posted for developer testing/voting (prior to being,
 potentially, formally blessed as a GA release).
 


### PR DESCRIPTION
Updated the release policy FAQ to reflect the use of the new Apache Trusted Releases platform and clarified the hosting of release candidates and nightly builds.