### PR TITLE
Add redirect for the release catalog PURL identifiers

### DIFF
--- a/content/.htaccess
+++ b/content/.htaccess
@@ -9,6 +9,9 @@ Redirect /apache-name /history
 
 Redirect 301 /press/media /press/
 
+# Release catalog PURL indentifiers
+Redirect 302 /the+asf/ https://release-catalog.apache.org/the+asf/
+
 ErrorDocument 404 /404
 
 # Expose this for CSP builders


### PR DESCRIPTION
Fixes #743. Implemented as a 302 in case this URL changes, but I presume we'd switch it to 301 once definitive.